### PR TITLE
OPENEUROPA-632: Add minimum stability to drupal core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "openeuropa/code-review": "~0.3",
     "openeuropa/task-runner": "^0.5",
     "symfony/dom-crawler": "^3",
-    "webflo/drupal-core-require-dev": "~8.6"
+    "webflo/drupal-core-require-dev": "~8.6@alpha"
   },
   "scripts": {
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "drupal/core": "~8.6",
+    "drupal/core": "~8.6@alpha",
     "php": "^7.1"
   },
   "require-dev": {


### PR DESCRIPTION
## OPENEUROPA-632

### Description

Upgrade minimum stability of drupal core to use alpha versions whenever they are ready and avoid using dev versions.

### Change log

- Changed: Add alpha minimum stability to drupal core