### PR TITLE
OPENEUROPA-1488: Add hook_update for webtools analytics module.

### DIFF
--- a/modules/oe_webtools_analytics/oe_webtools_analytics.install
+++ b/modules/oe_webtools_analytics/oe_webtools_analytics.install
@@ -32,3 +32,14 @@ function oe_webtools_analytics_requirements($phase) {
 
   return $requirements;
 }
+
+/**
+ * Update oe_webtools_analytics.settings config instance, if value is empty.
+ */
+function oe_webtools_analytics_update_8001() {
+  if (!\Drupal::configFactory()->get(AnalyticsEventInterface::CONFIG_NAME)->get('instance')) {
+    $config = \Drupal::configFactory()->getEditable(AnalyticsEventInterface::CONFIG_NAME)
+      ->set('instance', 'testing');
+    $config->save(TRUE);
+  }
+}


### PR DESCRIPTION
## OPENEUROPA-1488

### Description
In OPENEUROPA-1465 we have added a new parameter to the webtools configuration.

Every configuration schema change should be accompanied by a related hook update that updates the configuration in the site active storage. For more information about updating configuration via hook updates check the official documentation.