### PR TITLE
OPENEUROPA-1502: Add cache to Webtools Analytics rules.

### DIFF
--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/oe_webtools_analytics_rules.services.yml
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/oe_webtools_analytics_rules.services.yml
@@ -1,7 +1,7 @@
 services:
   oe_webtools_analytics_rules.event_subscriber:
     class: Drupal\oe_webtools_analytics_rules\EventSubscriber\WebtoolsAnalyticsEventSubscriber
-    arguments: ['@entity_type.manager', '@request_stack']
+    arguments: ['@entity_type.manager', '@request_stack', '@cache.webtools_analytics_rules']
     tags:
       - { name: event_subscriber }
   cache_context.webtools_analytics_section:
@@ -9,3 +9,9 @@ services:
     arguments: ['@oe_webtools_analytics_rules.event_subscriber']
     tags:
       - { name: cache.context }
+  cache.webtools_analytics_rules:
+    class: Drupal\Core\Cache\CacheBackendInterface
+    tags:
+      - { name: cache.bin, default_backend: cache.backend.chainedfast }
+    factory: cache_factory:get
+    arguments: [webtools_analytics_rules]


### PR DESCRIPTION
## OPENEUROPA-1502

### Description

Currently when navigating to a page the webtools analytics rules module goes through all existing rules to match the path to a rule. 
In order to increase performance we would need to add a cache that stores the rule ids that apply for each visited path.

Would be good to have a separate cache bin for this where the CID would be the path and the data would be the info that needs to be added to analytics (for the moment, we only have section).