### PR TITLE
Update the info file according to best practices

### DIFF
--- a/modules/oe_webtools_analytics/oe_webtools_analytics.info.yml
+++ b/modules/oe_webtools_analytics/oe_webtools_analytics.info.yml
@@ -1,8 +1,7 @@
 name: OpenEuropa Webtools Analytics
-description: Provides the configuration settings for webtools analytics integration.
+description: Provides integration with Webtools Analytics.
 package: OpenEuropa Webtools
 type: module
-version: 1.0
 core: 8.x
 configure: oe_webtools_analytics.settings
 


### PR DESCRIPTION
## OPENEUROPA-0000

### Description

The info file for the `oe_webtools_analytics` submodule is not following the best practices as outlined in the documentation page [Let Drupal 8 know about your module with an .info.yml file](https://www.drupal.org/docs/8/creating-custom-modules/let-drupal-8-know-about-your-module-with-an-infoyml-file).

This PR fixes that.

### Changelog

- Changed: Info file
