### PR TITLE
OPENEUROPA-1898: Adjust behat tests for allowing use media standalone url only in tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0@beta",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_media": "dev-OPENEUROPA-1898",
+        "openeuropa/oe_media": "^1.0@beta",
         "openeuropa/task-runner": "~1.0.0-beta5",
         "phpunit/phpunit": "~6.0",
         "symfony/dom-crawler": "~3.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0@beta",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_media": "^1.0@beta",
+        "openeuropa/oe_media": "dev-OPENEUROPA-1898",
         "openeuropa/task-runner": "~1.0.0-beta5",
         "phpunit/phpunit": "~6.0",
         "symfony/dom-crawler": "~3.0"

--- a/tests/Behat/WebtoolsCookieConsentContext.php
+++ b/tests/Behat/WebtoolsCookieConsentContext.php
@@ -16,6 +16,26 @@ use Drupal\media\Entity\Media;
 class WebtoolsCookieConsentContext extends RawDrupalContext {
 
   /**
+   * The config context.
+   *
+   * @var \Drupal\DrupalExtension\Context\ConfigContext
+   */
+  protected $configContext;
+
+  /**
+   * Gathers some other contexts.
+   *
+   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
+   *   The before scenario scope.
+   *
+   * @BeforeScenario
+   */
+  public function gatherContexts(BeforeScenarioScope $scope) {
+    $environment = $scope->getEnvironment();
+    $this->configContext = $environment->getContext('Drupal\DrupalExtension\Context\ConfigContext');
+  }
+
+  /**
    * Enables the Media module.
    *
    * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
@@ -25,6 +45,9 @@ class WebtoolsCookieConsentContext extends RawDrupalContext {
    */
   public function enableModule(BeforeScenarioScope $scope): void {
     \Drupal::service('module_installer')->install(['oe_media']);
+
+    $this->configContext->setConfig('media.settings', 'standalone_url', TRUE);
+    \Drupal::service('router.builder')->rebuild();
   }
 
   /**


### PR DESCRIPTION
## OPENEUROPA-1898

### Description

Druapl 8.7 allows us to configure the Media canonical pages to be hidden or not. At the moment they are shown due to us needing them in the tests.
The scope of this ticket is to hide them and adjust the tests (Media + EWCMS).

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

