### PR TITLE
OPENEUROPA-1633: [oe_webtools] Provide priorities for analytics rules.

### DIFF
--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/config/schema/webtools_analytics_rule.schema.yml
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/config/schema/webtools_analytics_rule.schema.yml
@@ -14,5 +14,6 @@ oe_webtools_analytics_rules.webtools_analytics_rule.*:
     regex:
       type: string
       label: Regex
-    uuid:
-      type: string
+    weight:
+      type: integer
+      label: 'Weight'

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/oe_webtools_analytics_rules.install
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/oe_webtools_analytics_rules.install
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Contains installation hooks.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Set default weight for 'webtools_analytics_rule' config entities.
+ */
+function oe_webtools_analytics_rules_update_8001(): void {
+  $configs = \Drupal::entityTypeManager()->getStorage('webtools_analytics_rule')->loadMultiple();
+  foreach ($configs as $config) {
+    $config->set('weight', -9);
+    $config->save();
+  }
+}

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/oe_webtools_analytics_rules.post_update.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/oe_webtools_analytics_rules.post_update.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains installation hooks.
+ * Post update functions for OpenEuropa Webtools Analytics Rules module.
  */
 
 declare(strict_types = 1);
@@ -10,10 +10,12 @@ declare(strict_types = 1);
 /**
  * Set default weight for 'webtools_analytics_rule' config entities.
  */
-function oe_webtools_analytics_rules_update_8001(): void {
+function oe_webtools_analytics_rules_post_update_rules_default_weight(): void {
   $configs = \Drupal::entityTypeManager()->getStorage('webtools_analytics_rule')->loadMultiple();
   foreach ($configs as $config) {
-    $config->set('weight', -9);
-    $config->save();
+    if ($config->get('weight') === NULL) {
+      $config->set('weight', -10);
+      $config->save();
+    }
   }
 }

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/Entity/WebtoolsAnalyticsRule.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/Entity/WebtoolsAnalyticsRule.php
@@ -34,7 +34,9 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *   config_prefix = "webtools_analytics_rule",
  *   admin_permission = "administer webtools analytics",
  *   entity_keys = {
- *     "id" = "id"
+ *     "id" = "id",
+ *     "regexp" = "regexp",
+ *     "weight" = "weight"
  *   },
  *   links = {
  *     "canonical" = "/admin/structure/webtools_analytics_rule/{webtools_analytics_rule}",

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/Entity/WebtoolsAnalyticsRule.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/Entity/WebtoolsAnalyticsRule.php
@@ -35,7 +35,6 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *   admin_permission = "administer webtools analytics",
  *   entity_keys = {
  *     "id" = "id",
- *     "regexp" = "regexp",
  *     "weight" = "weight"
  *   },
  *   links = {

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/RuleMatcher.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/RuleMatcher.php
@@ -235,6 +235,13 @@ class RuleMatcher implements RuleMatcherInterface {
   protected function loadRules(array $ids = NULL): array {
     /** @var \Drupal\oe_webtools_analytics_rules\Entity\WebtoolsAnalyticsRule[] $rules */
     $rules = $this->getRuleEntityStorage()->loadMultiple($ids);
+
+    if (count($rules) > 1) {
+      uasort($rules, function (WebtoolsAnalyticsRuleInterface $a, WebtoolsAnalyticsRuleInterface $b) {
+        return ($a->get('weight') <=> $b->get('weight'));
+      });
+    }
+
     return $rules;
   }
 

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/WebtoolsAnalyticsRuleListBuilder.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/WebtoolsAnalyticsRuleListBuilder.php
@@ -4,22 +4,30 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_webtools_analytics_rules;
 
-use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Config\Entity\DraggableListBuilder;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\oe_webtools_analytics_rules\Entity\WebtoolsAnalyticsRuleInterface;
 
 /**
  * Listing of Webtools Analytics section rules.
  */
-class WebtoolsAnalyticsRuleListBuilder extends ConfigEntityListBuilder {
+class WebtoolsAnalyticsRuleListBuilder extends DraggableListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'oe_webtools_analytics_rules_list_builder_form';
+  }
 
   /**
    * {@inheritdoc}
    */
   public function buildHeader(): array {
     $header['section'] = $this->t('Section');
+    $header['regexp'] = $this->t('Regular expression');
     $header['match_on_site_default_language'] = $this->t('Match on path alias for site default language');
-    $header['regex'] = $this->t('Regular expression');
 
     return $header + parent::buildHeader();
   }
@@ -31,11 +39,24 @@ class WebtoolsAnalyticsRuleListBuilder extends ConfigEntityListBuilder {
     if (!$entity instanceof WebtoolsAnalyticsRuleInterface) {
       throw new \InvalidArgumentException('Only Webtools Analytics rules can be listed.');
     }
-    $row['section'] = $entity->getSection();
-    $row['match_on_site_default_language'] = $entity->matchOnSiteDefaultLanguage() ? $this->t('Yes') : $this->t('No');
-    $row['id'] = $entity->getRegex();
+    $header['section'] = $row['label'] = $entity->getSection();
+    $row['regexp'] = [
+      '#markup' => $entity->getRegex(),
+    ];
+    $row['match_on_site_default_language'] = [
+      '#markup' => $entity->matchOnSiteDefaultLanguage() ? $this->t('Yes') : $this->t('No'),
+    ];
 
     return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+    $form['#prefix'] = '<p>' . t('This page provides a drag-and-drop interface for managing matching priority of <em>webtools analytics rules</em> for each page.') . '</p>';
+    return $form;
   }
 
 }

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/WebtoolsAnalyticsRuleListBuilder.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/WebtoolsAnalyticsRuleListBuilder.php
@@ -39,9 +39,9 @@ class WebtoolsAnalyticsRuleListBuilder extends DraggableListBuilder {
     if (!$entity instanceof WebtoolsAnalyticsRuleInterface) {
       throw new \InvalidArgumentException('Only Webtools Analytics rules can be listed.');
     }
-    $header['section'] = $row['label'] = $entity->getSection();
+    $row['label'] = $entity->getSection();
     $row['regexp'] = [
-      '#markup' => $entity->getRegex(),
+      '#plain_text' => $entity->getRegex(),
     ];
     $row['match_on_site_default_language'] = [
       '#markup' => $entity->matchOnSiteDefaultLanguage() ? $this->t('Yes') : $this->t('No'),
@@ -55,7 +55,8 @@ class WebtoolsAnalyticsRuleListBuilder extends DraggableListBuilder {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildForm($form, $form_state);
-    $form['#prefix'] = '<p>' . t('This page provides a drag-and-drop interface for managing matching priority of <em>webtools analytics rules</em> for each page.') . '</p>';
+    $form['#prefix'] = '<p>' . $this->t('The analytics rules are processed from top to bottom. The order can be re-arranged through drag-and-drop.') . '</p>';
+
     return $form;
   }
 

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Functional/SectionRulesTest.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Functional/SectionRulesTest.php
@@ -29,7 +29,6 @@ class SectionRulesTest extends BrowserTestBase {
    * Test that sections for different rules are correctly rendered.
    */
   public function testSectionRender(): void {
-
     // Configure the site to use analytics.
     $config = \Drupal::configFactory()
       ->getEditable(AnalyticsEventInterface::CONFIG_NAME)
@@ -37,9 +36,11 @@ class SectionRulesTest extends BrowserTestBase {
       ->set("sitePath", "ec.europa.eu");
     $config->save();
 
+    $analytic_rules_storage = $this->container->get('entity_type.manager')
+      ->getStorage('webtools_analytics_rule');
+
     // Create first rule under the main administration page.
-    $this->container->get('entity_type.manager')
-      ->getStorage('webtools_analytics_rule')
+    $analytic_rules_storage
       ->create([
         'id' => 'id1',
         'section' => 'section1',
@@ -48,8 +49,7 @@ class SectionRulesTest extends BrowserTestBase {
       ->save();
 
     // Create a second rule under the main configuration page.
-    $this->container->get('entity_type.manager')
-      ->getStorage('webtools_analytics_rule')
+    $analytic_rules_storage
       ->create([
         'id' => 'id2',
         'section' => 'section2',
@@ -75,16 +75,14 @@ class SectionRulesTest extends BrowserTestBase {
 
     // Change weight of rules.
     /** @var \Drupal\oe_webtools_analytics_rules\Entity\WebtoolsAnalyticsRuleInterface $id2 */
-    $id2 = $this->container->get('entity_type.manager')
-      ->getStorage('webtools_analytics_rule')
+    $id2 = $analytic_rules_storage
       ->load('id1');
 
     $id2->set('weight', -9);
     $id2->save();
 
     /** @var \Drupal\oe_webtools_analytics_rules\Entity\WebtoolsAnalyticsRuleInterface $id2 */
-    $id2 = $this->container->get('entity_type.manager')
-      ->getStorage('webtools_analytics_rule')
+    $id2 = $analytic_rules_storage
       ->load('id2');
 
     $id2->set('weight', -10);

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Functional/SectionRulesTest.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Functional/SectionRulesTest.php
@@ -48,6 +48,40 @@ class SectionRulesTest extends BrowserTestBase {
     $this->assertSession()
       ->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"siteSection":"section1","is403":true}</script>');
 
+    $this->container->get('entity_type.manager')
+      ->getStorage('webtools_analytics_rule')
+      ->create([
+        'id' => 'id2',
+        'section' => 'section2',
+        'regex' => '/\/admin\/config/',
+      ])
+      ->save();
+
+    $this->drupalGet('admin/config');
+    $this->assertSession()
+      ->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"siteSection":"section1","is403":true}</script>');
+
+    // Reordering rules.
+    /** @var \Drupal\oe_webtools_analytics_rules\Entity\WebtoolsAnalyticsRuleInterface $id2 */
+    $id2 = $this->container->get('entity_type.manager')
+      ->getStorage('webtools_analytics_rule')
+      ->load('id1');
+
+    $id2->set('weight', -9);
+    $id2->save();
+
+    /** @var \Drupal\oe_webtools_analytics_rules\Entity\WebtoolsAnalyticsRuleInterface $id2 */
+    $id2 = $this->container->get('entity_type.manager')
+      ->getStorage('webtools_analytics_rule')
+      ->load('id2');
+
+    $id2->set('weight', -10);
+    $id2->save();
+
+    $this->drupalGet('admin/config');
+    $this->assertSession()
+      ->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"siteSection":"section2","is403":true}</script>');
+
   }
 
 }

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Kernel/AnalyticsRulesSubscriberTest.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Kernel/AnalyticsRulesSubscriberTest.php
@@ -272,77 +272,78 @@ class AnalyticsRulesSubscriberTest extends KernelTestBase {
       ],
       // Test a combination of rules that match on the default language and the
       // current language, with two different default languages.
-      // Note that the rule IDs are prefixed with numbers. This is because they
-      // are currently executed in alphabetical order. They should instead be
-      // ordered by a user defined priority.
-      // @todo Replace the number prefixes with priorities once OPENEUROPA-1633
-      //   is fixed.
-      // @see https://webgate.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-1633
+      // Note that the rule IDs are ordered by a user defined priority
+      // based on weight.
       [
         [
           // The rule to match the news overview on the default language alias
           // when the default language is set to English.
-          '0_news_overview_default_language_alias_english' => [
+          'news_overview_default_language_alias_english' => [
             'section' => 'news overview (default language alias)',
             'regex' => '|^/news/?$|',
             'match_on_site_default_language' => TRUE,
+            'weight' => 0,
           ],
           // The rule to match the news overview on the default language alias
           // when the default language is set to Spanish.
-          '1_news_overview_default_language_alias_spanish' => [
+          'news_overview_default_language_alias_spanish' => [
             'section' => 'news overview (default language alias)',
             'regex' => '|^/nuevas/?$|',
             'match_on_site_default_language' => TRUE,
+            'weight' => 1,
           ],
           // A rule that checks if the current path matches a regular expression
           // for the system path of the Antarctican news overview page. Since
           // this appears earlier in the database than the following rule this
           // will take precedence over it.
-          // @todo The order of rules should be handled with a configurable
-          //   priority.
-          // @see https://webgate.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-1633
-          '2_antarctican_news_overview_current_path' => [
+          'antarctican_news_overview_current_path' => [
             'section' => 'overview of antarctican news (current path)',
             'regex' => '|^/taxonomy/term/344/?$|',
             'match_on_site_default_language' => FALSE,
+            'weight' => 2,
           ],
           // The Antarctican news overview page set up to match the default
           // language alias in English.
-          '3_antarctican_news_overview_default_language_alias_english' => [
+          'antarctican_news_overview_default_language_alias_english' => [
             'section' => 'overview of antarctican news (default language alias)',
             'regex' => '|^/news/antarctica/?$|',
             'match_on_site_default_language' => TRUE,
+            'weight' => 3,
           ],
           // The Antarctican news overview page set up to match the default
           // language alias in Spanish.
-          '4_antarctican_news_overview_default_language_alias_spanish' => [
+          'antarctican_news_overview_default_language_alias_spanish' => [
             'section' => 'overview of antarctican news (default language alias)',
             'regex' => '|^/es/nuevas/antartida/?$|',
             'match_on_site_default_language' => TRUE,
+            'weight' => 4,
           ],
           // The articles overview set up to match the default language alias
           // in English. Note that the English alias has not been created. This
           // should still be possible to match if the Pathauto module is
           // enabled and OPENEUROPA-1637 is fixed.
-          '5_articles_overview_default_language_alias_english' => [
+          'articles_overview_default_language_alias_english' => [
             'section' => 'overview of articles (default language alias)',
             'regex' => '|^/articles/?$|',
             'match_on_site_default_language' => TRUE,
+            'weight' => 5,
           ],
           // The articles overview matching the current path with a regex that
           // looks for the system path. This has been defined to have a lower
           // priority than the rules that match the default site aliases.
-          '6_articles_overview_current_path' => [
+          'articles_overview_current_path' => [
             'section' => 'overview of articles (current path)',
             'regex' => '|^/articles_page/?$|',
             'match_on_site_default_language' => FALSE,
+            'weight' => 6,
           ],
           // The articles overview matching the current path with a regex that
           // looks for the system path, with a match on the default language.
-          '7_articles_overview_default_language_alias' => [
+          'articles_overview_default_language_alias' => [
             'section' => 'overview of articles (default language alias)',
             'regex' => '|^/articles_page/?$|',
             'match_on_site_default_language' => TRUE,
+            'weight' => 7,
           ],
         ],
         [
@@ -461,6 +462,7 @@ class AnalyticsRulesSubscriberTest extends KernelTestBase {
         'section' => $rule_data['section'],
         'regex' => $rule_data['regex'],
         'match_on_site_default_language' => $rule_data['match_on_site_default_language'],
+        'weight' => $rule_data['weight'] ?? NULL,
       ])->save();
     }
   }

--- a/tests/Behat/WebtoolsAnalyticsMinkContext.php
+++ b/tests/Behat/WebtoolsAnalyticsMinkContext.php
@@ -72,7 +72,7 @@ class WebtoolsAnalyticsMinkContext extends MinkContext {
    * Change the weight of table row.
    *
    * Attempts to find the weight select box in a table row
-   * containing giving text.This is for administrative pages with ability
+   * containing giving text. This is for administrative pages with ability
    * to change the weight.
    *
    * @param string $weight
@@ -84,7 +84,7 @@ class WebtoolsAnalyticsMinkContext extends MinkContext {
    *
    * @throws \Behat\Mink\Exception\ElementNotFoundException
    */
-  public function assertClickInTableRow($weight, $rowText): void {
+  public function assertClickInTableRow(string $weight, string $rowText): void {
     $page = $this->getSession()->getPage();
     if ($weight_element = $this->getTableRow($page, $rowText)->find('css', 'select.weight')) {
       // Click the link and return.
@@ -109,7 +109,7 @@ class WebtoolsAnalyticsMinkContext extends MinkContext {
    *
    * @see \Drupal\DrupalExtension\Context\DrupalContext::getTableRow
    */
-  public function getTableRow(Element $element, $search): NodeElement {
+  public function getTableRow(Element $element, string $search): NodeElement {
     $rows = $element->findAll('css', 'tr');
     if (empty($rows)) {
       throw new \Exception(sprintf('No rows found on the page %s', $this->getSession()->getCurrentUrl()));

--- a/tests/Behat/WebtoolsAnalyticsMinkContext.php
+++ b/tests/Behat/WebtoolsAnalyticsMinkContext.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_webtools\Behat;
 
+use Behat\Mink\Element\Element;
+use Behat\Mink\Element\NodeElement;
 use Drupal\DrupalExtension\Context\MinkContext;
 use PHPUnit\Framework\Assert;
 
@@ -64,6 +66,60 @@ class WebtoolsAnalyticsMinkContext extends MinkContext {
     if (!$json_found) {
       throw new \Exception(sprintf('No analytics json found.'));
     }
+  }
+
+  /**
+   * Change the weight of table row.
+   *
+   * Attempts to find the weight select box in a table row
+   * containing giving text.This is for administrative pages with ability
+   * to change the weight.
+   *
+   * @param string $weight
+   *   The new weight value.
+   * @param string $rowText
+   *   The text to search for in the table row.
+   *
+   * @When I select :weight weight in the :rowText row
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   */
+  public function assertClickInTableRow($weight, $rowText): void {
+    $page = $this->getSession()->getPage();
+    if ($weight_element = $this->getTableRow($page, $rowText)->find('css', 'select.weight')) {
+      // Click the link and return.
+      $weight_element->selectOption($weight);
+      return;
+    }
+    throw new \Exception(sprintf('Found a row containing "%s", but no weight select box on the page %s', $rowText, $this->getSession()->getCurrentUrl()));
+  }
+
+  /**
+   * Retrieve a table row containing specified text from a given element.
+   *
+   * @param \Behat\Mink\Element\Element $element
+   *   The element.
+   * @param string $search
+   *   The text to search for in the table row.
+   *
+   * @return \Behat\Mink\Element\NodeElement
+   *   The searched element.
+   *
+   * @throws \Exception
+   *
+   * @see \Drupal\DrupalExtension\Context\DrupalContext::getTableRow
+   */
+  public function getTableRow(Element $element, $search): NodeElement {
+    $rows = $element->findAll('css', 'tr');
+    if (empty($rows)) {
+      throw new \Exception(sprintf('No rows found on the page %s', $this->getSession()->getCurrentUrl()));
+    }
+    foreach ($rows as $row) {
+      if (strpos($row->getText(), $search) !== FALSE) {
+        return $row;
+      }
+    }
+    throw new \Exception(sprintf('Failed to find a row containing "%s" on the page %s', $search, $this->getSession()->getCurrentUrl()));
   }
 
 }

--- a/tests/features/site-section.feature
+++ b/tests/features/site-section.feature
@@ -8,6 +8,7 @@ Feature: Webtools Analytics Site Section
     Given I am logged in as a user with the "administer webtools analytics" permission
     And the Webtools Analytics configuration is set to use the id '123' and the site path 'sitePath'
 
+  @cleanup:webtools_analytics_rule
   Scenario: Create Webtools Analytics Rule
     Given I am on "the Webtools Analytics rule creation page"
     And I fill in "Machine-readable name" with "rule1"
@@ -15,17 +16,54 @@ Feature: Webtools Analytics Site Section
     And I fill in "Regular expression" with "|^/custompath/?$|"
     When I press "Save"
     Then I should be on "the Webtools Analytics rule page"
-    Then I should see "examplesection"
-    # Check the rule applies
-    Given I am on "custompath"
+    And I should see "examplesection"
+    # Check the rule applies.
+    When I am on "custompath"
     Then the page analytics json should contain the parameter "siteSection" with the value "examplesection"
 
+  @cleanup:webtools_analytics_rule
   Scenario: Delete Webtools Analytics Rule
-    Given I am on "the Webtools Analytics rule page"
+    Given I am on "the Webtools Analytics rule creation page"
+    And I fill in "Machine-readable name" with "rule1"
+    And I fill in "Section" with "examplesection"
+    And I fill in "Regular expression" with "|^/custompath/?$|"
+    And I press "Save"
+    When I am on "the Webtools Analytics rule page"
     And I click "Delete" in the "examplesection" row
     And I press "Delete"
     Then I should be on "the Webtools Analytics rule page"
-    Then I should not see "examplesection"
-    # Check the rule doesnt apply
-    Given I am on "custompath"
+    And I should not see "examplesection"
+    # Check the rule doesnt apply.
+    When I am on "custompath"
     Then the page analytics json should not contain the parameter "siteSection"
+
+  @cleanup:webtools_analytics_rule @weight
+  Scenario: Make sure that Webtools Analytics Rules applies by priority
+    Given I am on "the Webtools Analytics rule creation page"
+    And I fill in "Machine-readable name" with "rule1"
+    And I fill in "Section" with "examplesection1"
+    And I fill in "Regular expression" with "|^/custompath|"
+    When I press "Save"
+    Then I should be on "the Webtools Analytics rule page"
+    And I should see "examplesection1"
+    # Check the rule applies.
+    When I am on "custompath"
+    Then the page analytics json should contain the parameter "siteSection" with the value "examplesection1"
+
+    When I am on "the Webtools Analytics rule creation page"
+    And I fill in "Machine-readable name" with "rule2"
+    And I fill in "Section" with "examplesection2"
+    And I fill in "Regular expression" with "|^/custompath/subpage|"
+    And I press "Save"
+    Then I should be on "the Webtools Analytics rule page"
+    And I should see "examplesection2"
+    # We still see applying of previous rule.
+    When I am on "custompath/subpage"
+    Then the page analytics json should contain the parameter "siteSection" with the value "examplesection1"
+    # We are setting higher priority for the new rule.
+    When I am on "the Webtools Analytics rule page"
+    And I select "-9" weight in the "examplesection1" row
+    And I select "-10" weight in the "examplesection2" row
+    And I press "Save"
+    And I am on "custompath/subpage"
+    Then the page analytics json should contain the parameter "siteSection" with the value "examplesection2"

--- a/tests/features/site-section.feature
+++ b/tests/features/site-section.feature
@@ -33,11 +33,11 @@ Feature: Webtools Analytics Site Section
     And I press "Delete"
     Then I should be on "the Webtools Analytics rule page"
     And I should not see "examplesection"
-    # Check the rule doesnt apply.
+    # Check the rule doesn't apply.
     When I am on "custompath"
     Then the page analytics json should not contain the parameter "siteSection"
 
-  @cleanup:webtools_analytics_rule @weight
+  @cleanup:webtools_analytics_rule
   Scenario: Make sure that Webtools Analytics Rules applies by priority
     Given I am on "the Webtools Analytics rule creation page"
     And I fill in "Machine-readable name" with "rule1"
@@ -60,7 +60,7 @@ Feature: Webtools Analytics Site Section
     # We still see applying of previous rule.
     When I am on "custompath/subpage"
     Then the page analytics json should contain the parameter "siteSection" with the value "examplesection1"
-    # We are setting higher priority for the new rule.
+    # Re-order the rules to change their priority.
     When I am on "the Webtools Analytics rule page"
     And I select "-9" weight in the "examplesection1" row
     And I select "-10" weight in the "examplesection2" row


### PR DESCRIPTION
## OPENEUROPA-1633

### Description

It is possible that there are multiple rules that match a given path. If this is the case we should allow administrators to define which rule should be used.

Let's say for example the following three rules are defined:

| Expression | Section |
| --- | --- |
| `\|^/admin/\|` | Site administration |
| `\|^/admin/config/\|` | Site configuration |
| `\|^/admin/config/search/\|` | Search configuration |

If the user is on the path `/admin/config/search/path/patterns` then the best match is the "Search configuration" section and not the generic "Site administration".

There are different ways to provide this prioritisation and we could make it very advanced, but for an initial version it could be as simple as providing a drag & drop functionality that allows the administrators to reorder the rules, and put the higher priority ones at the top.

Dev hint: take a look at the workflow states for an example of table drag and entities.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

