### PR TITLE
Add smartloader to analytics.

### DIFF
--- a/modules/oe_webtools_analytics/oe_webtools_analytics.module
+++ b/modules/oe_webtools_analytics/oe_webtools_analytics.module
@@ -42,4 +42,5 @@ function oe_webtools_analytics_page_attachments(array &$attachments): void {
     // A key, to make it possible to recognize this when altering.
     'oe_webtools_analytics',
   ];
+  $attachments['#attached']['library'][] = 'oe_webtools/drupal.webtools-smartloader';
 }


### PR DESCRIPTION
## ISAICP-4974

### Description

Smartloader is not included in pages, therefore, no pages get tracked.