### PR TITLE
ISAICP-5347: Support also the CCK banner and video_embed_field.

### DIFF
--- a/modules/oe_webtools_cookie_consent/README.md
+++ b/modules/oe_webtools_cookie_consent/README.md
@@ -1,0 +1,12 @@
+# OpenEuropa Webtools Cookie consent
+The OpenEuropa Webtools Cookie consent provides integration with the Cookie consent service.
+
+## How to use
+Simply install the module and all available options will be enabled. Uninstall the module to disable the services.
+
+## What it does
+The `oe_webtools_cookie_consent` module performs 3 different tasks:
+* Provides a banner that allows the user whether to accept or refuse tickets from the website.
+* Preprocesses the media_oembed iframes and alters the URL to go through the EC cookie consent service.
+* Preprocesses iframes provided by the video_embed_field or the video_embed_wysiwyg modules and also redirects
+the source through the EC cookie consent service.

--- a/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.info.yml
+++ b/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.info.yml
@@ -1,5 +1,5 @@
-name: OpenEuropa Webtools Cookie consent
-description: Provides the Cookie consent kit service functionality.
+name: OpenEuropa Webtools Cookie Consent
+description: Provides the Cookie Consent Kit service functionality.
 package: OpenEuropa Webtools
 type: module
 version: 1.0

--- a/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.libraries.yml
+++ b/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.libraries.yml
@@ -1,0 +1,3 @@
+oe_webtools_cookie_consent.cck:
+  js:
+    https://ec.europa.eu/wel/cookie-consent/consent.js: { type: external, minified: false }

--- a/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.module
+++ b/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.module
@@ -2,12 +2,23 @@
 
 /**
  * @file
- * OpenEuropa Webtools cookie consent module.
+ * OpenEuropa Webtools Cookie Consent module.
  */
 
 declare(strict_types = 1);
 
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Url;
 use Drupal\media\IFrameMarkup;
+
+define('OE_WEBTOOLS_COOKIE_CONSENT_EMBED_COOKIE_URL', '//europa.eu/webtools/crs/iframe/?oriurl=');
+
+/**
+ * Implements hook_page_attachments().
+ */
+function oe_webtools_cookie_consent_page_attachments(array &$attachments) {
+  $attachments['#attached']['library'][] = 'oe_webtools_cookie_consent/oe_webtools_cookie_consent.cck';
+}
 
 /**
  * Implements template_preprocess_media_oembed_iframe().
@@ -24,4 +35,43 @@ function oe_webtools_cookie_consent_preprocess_media_oembed_iframe(array &$varia
       $variables['media'] = IFrameMarkup::create($new_iframe);
     }
   }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function oe_webtools_cookie_consent_preprocess_video_embed_iframe(&$variables) {
+  // Override the default url and pass it to the ec cck url but ignore iframes
+  // that refer to the same site.
+  if (!empty($variables['url']) && !UrlHelper::externalIsLocal($variables['url'], \Drupal::request()->getSchemeAndHttpHost())) {
+    // video_embed_field prints every part of the URL separately and prints some
+    // key characters in the twig directly (e.g. the '#' for the anchor).
+    // This makes it difficult to properly encode the full URL to pass it to the
+    // cck domain.
+    // Also, the values of the query parameters that are of type
+    // boolean, are converted wrongly because the Url class handles them
+    // differently than the http_build_query method.
+    //
+    // @todo: Remove the workaround once this is fixed in core.
+    // @see \Drupal\Component\Utility\UrlHelper::buildQuery
+    // @see https://www.drupal.org/project/drupal/issues/2248257
+    if (is_array($variables['query'])) {
+      array_walk($variables['query'], function (&$value) {
+        if (is_bool($value)) {
+          $value = (int) $value;
+        }
+      });
+    }
+
+    $url = Url::fromUri($variables['url'], [
+      'query' => $variables['query'],
+      // Fragment is returned as an array, so give NULL to avoid type errors.
+      'fragment' => empty($variables['fragment']) ? NULL : $variables['fragment'],
+      'absolute' => TRUE,
+    ]);
+    $variables['url'] = OE_WEBTOOLS_COOKIE_CONSENT_EMBED_COOKIE_URL . urlencode($url->setAbsolute()->toString());
+    unset($variables['query']);
+    unset($variables['fragment']);
+  }
+
 }

--- a/tests/features/cookie-consent-kit.feature
+++ b/tests/features/cookie-consent-kit.feature
@@ -27,9 +27,8 @@ Feature: Cookie consent kit.
     Then I should not see the "Cookie consent banner" region
 
     # Logging in does not require re-sign in.
-    When I am on the homepage
-    And I click "Sign in"
-    And I fill in "Email or username" with "test_cck"
+    When I go to "/user"
+    And I fill in "Username" with "test_cck"
     And I fill in "Password" with "test_cck"
     And I press "Sign in"
     Then I should not see the "Cookie consent banner" region

--- a/tests/features/cookie-consent-kit.feature
+++ b/tests/features/cookie-consent-kit.feature
@@ -10,3 +10,31 @@ Feature: Cookie consent kit.
       | url                                         | title                  |
       | https://www.youtube.com/watch?v=1-g73ty9v04 | Energy, let's save it! |
     Then I should see the oEmbed video iframe with cookie consent
+
+  @javascript
+  Scenario Outline: Accept cookies
+    Given user:
+      | Username | test_cck |
+      | Password | test_cck |
+
+    When I am an anonymous user
+    And I am on the homepage
+    Then I should see the text "This site uses cookies to offer you a better browsing experience. Find out more on how we use cookies and how you can change your settings." in the "Cookie consent banner"
+    And I should see the link "I accept cookies" in the "Cookie consent banner"
+    And I should see the link "I refuse cookies" in the "Cookie consent banner"
+
+    When I click "I <link> cookies"
+    Then I should not see the "Cookie consent banner" region
+
+    # Logging in does not require re-sign in.
+    When I am on the homepage
+    And I click "Sign in"
+    And I fill in "Email or username" with "test_cck"
+    And I fill in "Password" with "test_cck"
+    And I press "Sign in"
+    Then I should not see the "Cookie consent banner" region
+
+    Examples:
+      | link   |
+      | accept |
+      | refuse |


### PR DESCRIPTION
## ISAICP-5347

### Description

Extend the functionality of the oe_webtools_cookie_consent submodule.

### Change log

- Added:
-- Include the external library that creates the cookie banner that allows the user to accept or refuse cookies.
-- Support embedded media offered by the video_embed_field and video_embed_wysiwyg modules.
