### PR TITLE
OPENEUROPA-2259: Fix behat/mink-selenium2-driver missing branch by aliasing.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,14 @@
         "openeuropa/task-runner": "~1.0.0-beta5",
         "openeuropa/webtools-geocoding-provider": "~0.1",
         "phpunit/phpunit": "~6.0",
-        "symfony/dom-crawler": "~3.0"
+        "symfony/dom-crawler": "~3.0",
+        "behat/mink-selenium2-driver": "dev-master#8684ee4 as 1.3.x-dev",
+        "behat/mink": "dev-master#a534fe7"
     },
+    "_readme": [
+        "We need to alias a specific version of 'behat/mink-selenium2-driver' to '1.3.x-dev' since this branch is not available any longer. For more information check: https://github.com/minkphp/MinkSelenium2Driver/issues/313.",
+        "Upcoming ~1.4 of 'behat/mink-selenium2-driver' is known to have issues with latest 'behat/mink', so we need to pinpoint a specific version of the latter. For more information check: https://www.drupal.org/project/drupal/issues/3078671#comment-13244409."
+    ],
     "conflict": {
         "openeuropa/oe_webtools_location": "*"
     },


### PR DESCRIPTION
## OPENEUROPA-2259
### Description

 Fix behat/mink-selenium2-driver missing branch by aliasing.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:  Fix behat/mink-selenium2-driver missing branch by aliasing.
- Security:

### Commands

```sh
[Insert commands here]

```

