### PR TITLE
Add the @group to LacoServiceTest

### DIFF
--- a/modules/oe_webtools_laco_service/tests/src/Kernel/LacoServiceTest.php
+++ b/modules/oe_webtools_laco_service/tests/src/Kernel/LacoServiceTest.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests the Laco service functionality.
+ * 
+ * @group oe_webtools_laco_service
  */
 class LacoServiceTest extends KernelTestBase {
 


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

Missing the `@group` in test classes make the old Simpletest fail.

