### PR TITLE
ISAICP-5502: Allow to pass an optional referer

### DIFF
--- a/modules/oe_webtools_geocoding/config/schema/oe_webtools_geocoding.schema.yml
+++ b/modules/oe_webtools_geocoding/config/schema/oe_webtools_geocoding.schema.yml
@@ -1,3 +1,9 @@
 geocoder_provider.configuration.webtools_geocoding:
   type: geocoder_provider_configuration
   label: 'Webtools Geocoding configuration'
+  mapping:
+    referer:
+      type: string
+      label: 'Referer'
+      description: 'Value of the Referer header'
+      nullable: true

--- a/modules/oe_webtools_geocoding/config/schema/oe_webtools_geocoding.schema.yml
+++ b/modules/oe_webtools_geocoding/config/schema/oe_webtools_geocoding.schema.yml
@@ -3,7 +3,7 @@ geocoder_provider.configuration.webtools_geocoding:
   label: 'Webtools Geocoding configuration'
   mapping:
     referer:
-      type: string
+      type: uri
       label: 'Referer'
       description: 'Value of the Referer header'
       nullable: true

--- a/modules/oe_webtools_geocoding/src/Plugin/Geocoder/Provider/WebtoolsGeocoding.php
+++ b/modules/oe_webtools_geocoding/src/Plugin/Geocoder/Provider/WebtoolsGeocoding.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_webtools_geocoding\Plugin\Geocoder\Provider;
 
-use Drupal\geocoder\ProviderUsingHandlerWithAdapterBase;
+use Drupal\geocoder\ConfigurableProviderUsingHandlerWithAdapterBase;
 
 /**
  * Webtools Geocoding provider for the Geocoder module.
@@ -13,6 +13,9 @@ use Drupal\geocoder\ProviderUsingHandlerWithAdapterBase;
  *   id = "webtools_geocoding",
  *   name = "Webtools Geocoding",
  *   handler = "\OpenEuropa\Provider\WebtoolsGeocoding\WebtoolsGeocoding",
+ *   arguments = {
+ *     "referer" = ""
+ *   }
  * )
  */
-class WebtoolsGeocoding extends ProviderUsingHandlerWithAdapterBase {}
+class WebtoolsGeocoding extends ConfigurableProviderUsingHandlerWithAdapterBase {}

--- a/modules/oe_webtools_geocoding/src/Plugin/Geocoder/Provider/WebtoolsGeocoding.php
+++ b/modules/oe_webtools_geocoding/src/Plugin/Geocoder/Provider/WebtoolsGeocoding.php
@@ -14,8 +14,8 @@ use Drupal\geocoder\ConfigurableProviderUsingHandlerWithAdapterBase;
  *   name = "Webtools Geocoding",
  *   handler = "\OpenEuropa\Provider\WebtoolsGeocoding\WebtoolsGeocoding",
  *   arguments = {
- *     "referer" = ""
- *   }
+ *     "referer" = NULL,
+ *   },
  * )
  */
 class WebtoolsGeocoding extends ConfigurableProviderUsingHandlerWithAdapterBase {}


### PR DESCRIPTION
## ISAICP-5502

### Description

The Webtools Geocoding REST API requires the referer header to be set for certain projects that are behind a load balancer.

For the majority of projects this is not required, so the header should be optional.

For more information see:
- https://webgate.ec.europa.eu/CITnet/jira/browse/WEBTOOLS-9197
- https://webgate.ec.europa.eu/CITnet/jira/browse/ISAICP-5502

See also https://github.com/openeuropa/webtools-geocoding-provider/pull/6

### Change log

- Added: Option to pass a referer to the Webtools Geocoding provider