### PR TITLE
ISAICP-5450: Make Cookie Consent step definitions reusable

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -13,6 +13,7 @@ default:
         - Drupal\Tests\oe_webtools\Behat\WebtoolsCookieConsentContext
         - Drupal\Tests\oe_webtools\Behat\WebtoolsCleanupContext
         - Drupal\Tests\oe_webtools\Behat\WebtoolsGlobanContext
+        - FeatureContext
         - OpenEuropa\Behat\TransformationContext:
             pages:
               Webtools Analytics configuration: '/admin/config/system/oe_webtools_analytics'

--- a/tests/Behat/WebtoolsCookieConsentContext.php
+++ b/tests/Behat/WebtoolsCookieConsentContext.php
@@ -4,11 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_webtools\Behat;
 
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Gherkin\Node\TableNode;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
-use Drupal\media\Entity\Media;
 
 define('OE_WEBTOOLS_COOKIE_CONSENT_EMBED_COOKIE_URL', '//europa.eu/webtools/crs/iframe/');
 define('OE_WEBTOOLS_COOKIE_CONSENT_BANNER_COOKIE_URL', '//ec.europa.eu/wel/cookie-consent/consent.js');
@@ -17,76 +13,6 @@ define('OE_WEBTOOLS_COOKIE_CONSENT_BANNER_COOKIE_URL', '//ec.europa.eu/wel/cooki
  * Behat step definitions related to the oe_webtools_cookie_consent module.
  */
 class WebtoolsCookieConsentContext extends RawDrupalContext {
-
-  /**
-   * The config context.
-   *
-   * @var \Drupal\DrupalExtension\Context\ConfigContext
-   */
-  protected $configContext;
-
-  /**
-   * Gathers some other contexts.
-   *
-   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
-   *   The before scenario scope.
-   *
-   * @BeforeScenario
-   */
-  public function gatherContexts(BeforeScenarioScope $scope) {
-    $environment = $scope->getEnvironment();
-    $this->configContext = $environment->getContext('Drupal\DrupalExtension\Context\ConfigContext');
-  }
-
-  /**
-   * Enables the Media module.
-   *
-   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
-   *   The scope.
-   *
-   * @beforeScenario @remote-video
-   */
-  public function enableModule(BeforeScenarioScope $scope): void {
-    \Drupal::service('module_installer')->install(['oe_media']);
-
-    $this->configContext->setConfig('media.settings', 'standalone_url', TRUE);
-    \Drupal::service('router.builder')->rebuild();
-  }
-
-  /**
-   * Disables the Media module.
-   *
-   * @param \Behat\Behat\Hook\Scope\AfterScenarioScope $scope
-   *   The scope.
-   *
-   * @afterScenario @remote-video
-   */
-  public function disableModule(AfterScenarioScope $scope): void {
-    \Drupal::service('module_installer')->uninstall(['oe_media']);
-  }
-
-  /**
-   * Create remote video entity and go to detail page of media.
-   *
-   * @param \Behat\Gherkin\Node\TableNode $mediasTable
-   *   Table of media data.
-   *
-   * @Given I visit the remote video entity page:
-   */
-  public function iVisitTheRemoteVideoEntityPage(TableNode $mediasTable): void {
-    $hash = $mediasTable->getColumnsHash();
-    $media_data = reset($hash);
-    if ($media_data) {
-      $media = Media::create([
-        'bundle' => 'remote_video',
-        'name' => $media_data['title'],
-        'oe_media_oembed_video' => $media_data['url'],
-        'path' => $media_data['path'],
-      ]);
-      $media->save();
-      $this->visitPath($media_data['path']);
-    }
-  }
 
   /**
    * Checks that an OEmbed iframe url uses CCK service.

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @file
+ * Contains step definitions specific to the internal scenarios of OE Webtools.
+ */
+
+declare(strict_types = 1);
+
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+use Drupal\media\Entity\Media;
+
+/**
+ * Defines non-reusable step definitions to use with OpenEuropa Webtools.
+ */
+class FeatureContext extends RawDrupalContext {
+
+  /**
+   * The config context.
+   *
+   * @var \Drupal\DrupalExtension\Context\ConfigContext
+   */
+  protected $configContext;
+
+  /**
+   * Gathers some other contexts.
+   *
+   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
+   *   The before scenario scope.
+   *
+   * @BeforeScenario
+   */
+  public function gatherContexts(BeforeScenarioScope $scope) {
+    $environment = $scope->getEnvironment();
+    $this->configContext = $environment->getContext('Drupal\DrupalExtension\Context\ConfigContext');
+  }
+
+  /**
+   * Enables the Media module.
+   *
+   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
+   *   The scope.
+   *
+   * @beforeScenario @remote-video
+   */
+  public function enableModule(BeforeScenarioScope $scope): void {
+    \Drupal::service('module_installer')->install(['oe_media']);
+
+    $this->configContext->setConfig('media.settings', 'standalone_url', TRUE);
+    \Drupal::service('router.builder')->rebuild();
+  }
+
+  /**
+   * Disables the Media module.
+   *
+   * @param \Behat\Behat\Hook\Scope\AfterScenarioScope $scope
+   *   The scope.
+   *
+   * @afterScenario @remote-video
+   */
+  public function disableModule(AfterScenarioScope $scope): void {
+    \Drupal::service('module_installer')->uninstall(['oe_media']);
+  }
+
+  /**
+   * Create remote video entity and go to detail page of media.
+   *
+   * @param \Behat\Gherkin\Node\TableNode $mediasTable
+   *   Table of media data.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   *   Thrown when the entity cannot be created.
+   *
+   * @Given I visit the remote video entity page:
+   */
+  public function iVisitTheRemoteVideoEntityPage(TableNode $mediasTable): void {
+    $hash = $mediasTable->getColumnsHash();
+    $media_data = reset($hash);
+    if ($media_data) {
+      $media = Media::create([
+        'bundle' => 'remote_video',
+        'name' => $media_data['title'],
+        'oe_media_oembed_video' => $media_data['url'],
+        'path' => $media_data['path'],
+      ]);
+      $media->save();
+      $this->visitPath($media_data['path']);
+    }
+  }
+
+}


### PR DESCRIPTION
## ISAICP-5450

### Description

In the [Joinup](https://github.com/ec-europa/joinup-dev) project we are planning to replace our custom cookie consent solution with `oe_webtools_cookie_consent` (ref. Jira ticket [ISAICP-5450](https://webgate.ec.europa.eu/CITnet/jira/browse/ISAICP-5450)).

We would like to be able to use the step definitions defined in `WebtoolsCookieConsentContext` but these currently contain code that is specific to the `oe_webtools` project and is related to the creating of certain media entities in the setup of the test scenarios and enabling/disabling modules needed for the scenarios.

In projects using Behat, any code that is specific to the local test suite and is not intended to be reusable should be put in the `features/bootstrap/` folder. All `Context` classes in this folder are discovered and added to the autoloader when the Behat application is bootstrapped. This means they are not exposed to the global autoloader, so they cannot be instantiated by any PHP code except for Behat in scope of the current test suite.

By moving the oe_webtools-specific code in this folder we can ensure that other projects can reuse the code in `WebtoolsCookieConsentContext` without risking to accidentally trigger the non-reusable code.

### Change log

- Changed: Move non-reusable Behat code into the private FeatureContext.
