### PR TITLE
Place the library on the header.

### DIFF
--- a/oe_webtools.libraries.yml
+++ b/oe_webtools.libraries.yml
@@ -1,5 +1,6 @@
 # Third-party library (CDN).
 drupal.webtools-smartloader:
   version: 1.x
+  header: true
   js:
    //europa.eu/webtools/load.js: { external: true, attributes: { defer: true } }


### PR DESCRIPTION
## ISAICP-5564

### Description

In Drupal 7 libraries were being placed on the header by default. For performance purposes, in D8 this changed and by default libraries are added in the footer. The relevant change record is https://www.drupal.org/node/2412769

We have an issue that the map (`oe_webtools_maps`) not displayed in some cases in Internet Explorer. I discussed with Catalin and he said that if we moved the library to the `<head>` element that would be fixed automatically. Indeed I tested forcing the library to the head and it seems to solve the issue.

Initially I though of creating a setting to control whether to put it in the header or the footer but I guess this is a compatibility matter.
Also, I see that two out of the three dummy html files used in the behat scenarios are including the script in the header.

Thus, I propose to add the `header: true` to the library so that it is added in the header by default.

### Change log

- Added: None
- Changed: The webtools loader library is added in the `<head>` element instead of the footer.
- Deprecated: None
- Removed: None
- Fixed: Same as changed.
- Security: None

Tests needed? Or is already covered by the current html files?
