### PR TITLE
Clean up media that were created during a scenario.

### DIFF
--- a/tests/features/cookie-consent-kit.feature
+++ b/tests/features/cookie-consent-kit.feature
@@ -26,13 +26,14 @@ Feature: Cookie Consent kit.
     When I am on homepage
     Then the CCK javascript is not loaded on the head section of the page
 
-  @remote-video @cleanup:media
+  @remote-video
   Scenario: Remote videos should use Cookie Consent kit service.
     # Check that the oEmbed video iframe with Cookie Consent.
     Given I am an anonymous user
-    When I visit the remote video entity page:
+    Given the following remote video entity:
       | url                                         | title                  | path         |
       | https://www.youtube.com/watch?v=1-g73ty9v04 | Energy, let's save it! | /media/test  |
+    When I visit the remote video entity page "Energy, let's save it!"
     Then I should see the oEmbed video iframe with Cookie Consent
 
     # Change the configuration.


### PR DESCRIPTION
This is a WIP implementation of #103 but unfortunately I am running out of time on my ticket and I can not finish this today. Here is the code so far. The idea is to not rely on magic for cleaning up media entities created during a scenario, but to keep track of the entities that are created, and clean them up at the end of the test.