### PR TITLE
ISAICP-4998: Allow the formatter to automatically show the marker of the coordinates.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,8 @@
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpro/grumphp": true
+            "phpro/grumphp": true,
+            "php-http/discovery": false
         }
     }
 }

--- a/modules/oe_webtools_maps/config/schema/oe_webtools_maps.schema.yml
+++ b/modules/oe_webtools_maps/config/schema/oe_webtools_maps.schema.yml
@@ -2,6 +2,9 @@ field.formatter.settings.oe_webtools_maps_map:
   type: mapping
   label: Webtools Map formatter settings
   mapping:
+    show_marker:
+      type: boolean
+      label: 'Show marker'
     zoom_level:
       type: integer
       label: 'Zoom level'

--- a/modules/oe_webtools_maps/src/Plugin/Field/FieldFormatter/WebtoolsMapFormatter.php
+++ b/modules/oe_webtools_maps/src/Plugin/Field/FieldFormatter/WebtoolsMapFormatter.php
@@ -91,6 +91,13 @@ class WebtoolsMapFormatter extends FormatterBase {
               'features' => [
                 [
                   'type' => 'Feature',
+                  'properties' => [
+                    'name' => t('Coordinates'),
+                    'description' => t('Longitude: @lon, Latitude: @lat', [
+                      '@lon' => $item->get('lon')->getValue(),
+                      '@lat' => $item->get('lat')->getValue(),
+                    ]),
+                  ],
                   'geometry' => [
                     'type' => 'Point',
                     'coordinates' => [

--- a/modules/oe_webtools_maps/src/Plugin/Field/FieldFormatter/WebtoolsMapFormatter.php
+++ b/modules/oe_webtools_maps/src/Plugin/Field/FieldFormatter/WebtoolsMapFormatter.php
@@ -61,7 +61,7 @@ class WebtoolsMapFormatter extends FormatterBase {
   public function settingsSummary() {
     $summary[] = $this->t('Zoom level: @zoom_level, Show markers: @show_marker', [
       '@zoom_level' => $this->getSetting('zoom_level'),
-      '@show_marker' => $this->getSetting('show_marker') ? 'Yes' : 'No',
+      '@show_marker' => $this->getSetting('show_marker') ? $this->t('Yes') : $this->t('No'),
     ]);
     return $summary;
   }
@@ -76,7 +76,6 @@ class WebtoolsMapFormatter extends FormatterBase {
       $data_array = [
         'service' => 'map',
         'version' => '2.0',
-        'render' => TRUE,
         'map' => [
           'zoom' => $this->getSetting('zoom_level'),
           'center' => [$item->get('lat')->getValue(), $item->get('lon')->getValue()],
@@ -92,8 +91,8 @@ class WebtoolsMapFormatter extends FormatterBase {
                 [
                   'type' => 'Feature',
                   'properties' => [
-                    'name' => t('Coordinates'),
-                    'description' => t('Longitude: @lon, Latitude: @lat', [
+                    'name' => $this->t('Coordinates'),
+                    'description' => $this->t('Longitude: @lon, Latitude: @lat', [
                       '@lon' => $item->get('lon')->getValue(),
                       '@lat' => $item->get('lat')->getValue(),
                     ]),

--- a/modules/oe_webtools_maps/src/Plugin/Field/FieldFormatter/WebtoolsMapFormatter.php
+++ b/modules/oe_webtools_maps/src/Plugin/Field/FieldFormatter/WebtoolsMapFormatter.php
@@ -39,7 +39,7 @@ class WebtoolsMapFormatter extends FormatterBase {
     $elements['show_marker'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Show marker'),
-      '#description' => $this->t('Show the marker according to the coordinates provided.'),
+      '#description' => $this->t('Show a marker at the provided coordinates.'),
       '#default_value' => $this->getSetting('show_marker'),
     ];
 

--- a/modules/oe_webtools_maps/src/Plugin/Field/FieldFormatter/WebtoolsMapFormatter.php
+++ b/modules/oe_webtools_maps/src/Plugin/Field/FieldFormatter/WebtoolsMapFormatter.php
@@ -78,7 +78,10 @@ class WebtoolsMapFormatter extends FormatterBase {
         'version' => '2.0',
         'map' => [
           'zoom' => $this->getSetting('zoom_level'),
-          'center' => [$item->get('lat')->getValue(), $item->get('lon')->getValue()],
+          'center' => [
+            $item->get('lat')->getValue(),
+            $item->get('lon')->getValue(),
+          ],
         ],
       ];
 

--- a/tests/Behat/WebtoolsMapsContext.php
+++ b/tests/Behat/WebtoolsMapsContext.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_webtools\Behat;
 
+use Behat\Gherkin\Node\TableNode;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use PHPUnit\Framework\Assert;
 

--- a/tests/Behat/WebtoolsMapsContext.php
+++ b/tests/Behat/WebtoolsMapsContext.php
@@ -39,6 +39,65 @@ class WebtoolsMapsContext extends RawDrupalContext {
   }
 
   /**
+   * Checks that a map with a marker with the given data is present.
+   *
+   * Table format:
+   * @codingStandardsIgnoreStart
+   * | name        | Digit HQ                           |
+   * | description | Rue Belliard 28, Brussels, Belgium |
+   * | latitude    | 4.370375                           |
+   * | longitude   | 50.842156                          |
+   * @codingStandardsIgnoreEnd
+   *
+   * @param \Behat\Gherkin\Node\TableNode $data
+   *   The data for the marker. Should contain one or more of the following
+   *   labels: 'name', 'description', 'latitude', 'longitude'.
+   *
+   * @throws \RuntimeException
+   *   If the map with the given marker was not found in the page.
+   *
+   * @Then I should see the following marker on the map:
+   */
+  public function assertMarkerPresent(TableNode $data): void {
+    $hashed_data = $data->getRowsHash();
+    foreach ($this->getWebtoolsMaps() as $map_data) {
+      foreach ($hashed_data as $type => $value) {
+        switch ($type) {
+          case 'name':
+            if ($map_data->layers[0]->markers->features[0]->properties->name !== $value) {
+              continue 3;
+            }
+            break;
+
+          case 'description':
+            if ($map_data->layers[0]->markers->features[0]->properties->description !== $value) {
+              continue 3;
+            }
+            break;
+
+          case 'latitude':
+            if ((string) $map_data->layers[0]->markers->features[0]->geometry->coordinates[1] !== $value) {
+              continue 3;
+            }
+            break;
+
+          case 'longitude':
+            if ((string) $map_data->layers[0]->markers->features[0]->geometry->coordinates[0] !== $value) {
+              continue 3;
+            }
+            break;
+
+          default:
+            throw new \RuntimeException("Unknown marker data property $type.");
+        }
+      }
+      // The marker was found.
+      return;
+    }
+    throw new \RuntimeException('No map found with a marker that corresponds to the data "' . implode(', ', $hashed_data) . '".');
+  }
+
+  /**
    * Checks that there are no maps on the current page.
    *
    * @Then I should not see a(ny) map(s) on the page

--- a/tests/Behat/WebtoolsMapsContext.php
+++ b/tests/Behat/WebtoolsMapsContext.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Assert;
 
 /**
  * Behat step definitions for testing Webtools Maps.
+ *
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  */
 class WebtoolsMapsContext extends RawDrupalContext {
 

--- a/tests/features/oe-webtools-maps-step-definitions.feature
+++ b/tests/features/oe-webtools-maps-step-definitions.feature
@@ -19,3 +19,8 @@ Scenario: Try out the different step definitions for detecting maps
   And I should see a map centered on latitude 2.34994 and longitude 48.85295
   And I should see a map on the page
   And I should see 2 maps on the page
+  And I should see the following marker on the map:
+    | name        | Digit HQ                           |
+    | description | Rue Belliard 28, Brussels, Belgium |
+    | latitude    | 50.842156                          |
+    | longitude   | 4.370375                           |

--- a/tests/fixtures/static_html/two_maps.html
+++ b/tests/fixtures/static_html/two_maps.html
@@ -14,7 +14,27 @@
           "map": {
             "zoom": 16,
             "center": [50.842156, 4.370375]
-          }
+          },
+          "layers":[
+            {
+              "markers":{
+                "type":"FeatureCollection",
+                "features":[
+                  {
+                    "type":"Feature",
+                    "properties":{
+                      "name":"Digit HQ",
+                      "description":"Rue Belliard 28, Brussels, Belgium"
+                    },
+                    "geometry":{
+                      "type":"Point",
+                      "coordinates": [4.370375, 50.842156]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       </script>
     </div>


### PR DESCRIPTION
## ISAICP-4998

### Description

Show the marker of the map by default.
It is quite easy and common to display a marker on the map when the coordinates are configured. 

Attempting a first patch to display the markers.
This will be optional - can be disabled in the formatter. The default value is false so that it does not affect existing projects.

Since the formatter is already using the lat and lon values, I am not checking for the existence of values but I could if you want.

### Change log

- Added: A setting to show a marker in the map by default.
