### PR TITLE
Check that the old and new webtools_maps contexts are identical.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -70,6 +70,9 @@ pipeline:
     commands:
       - ./vendor/bin/behat --strict
       - ./vendor/bin/behat --strict --profile=static
+      # Check that the deprecated subcontext in webtools_maps is identical to the new context.
+      - LINE_COUNT=$(($(wc -l ./tests/Behat/WebtoolsMapsContext.php | cut -d ' ' -f1) - $(grep -n '^class WebtoolsMapsContext' ./tests/Behat/WebtoolsMapsContext.php | cut -d : -f1)))
+      - diff <(tail -n $LINE_COUNT ./tests/Behat/WebtoolsMapsContext.php) <(tail -n $LINE_COUNT ./modules/oe_webtools_maps/oe_webtools_maps.behat.inc)
 
   debug:
     image: fpfis/httpd-php-ci:7.1


### PR DESCRIPTION
### Description

For Webtools Maps we currently maintain both the deprecated `OeWebtoolsMapsSubcontext` and the new `WebtoolsMapsContext`. Both are supposed to contain identical code, but we have no checks in place to ensure this. The tests only cover the new context.

There appears to be a small divergence already.

Fixes #112

### Change log

- Added: Automated check to ensure both Behat contexts for Webtools Maps remain synchronised.
