### PR TITLE
ISAICP-5648: Allow selective display of banner

### DIFF
--- a/modules/oe_webtools_globan/config/install/oe_webtools_globan.settings.yml
+++ b/modules/oe_webtools_globan/config/install/oe_webtools_globan.settings.yml
@@ -2,3 +2,6 @@ display_eu_flag: true
 background_theme: 'dark'
 display_eu_institutions_links: true
 override_page_lang: ''
+visibility:
+  action: show
+  pages: ''

--- a/modules/oe_webtools_globan/config/schema/oe_webtools_globan.schema.yml
+++ b/modules/oe_webtools_globan/config/schema/oe_webtools_globan.schema.yml
@@ -18,3 +18,13 @@ oe_webtools_globan.settings:
       type: string
       label: 'Override page language'
       description: 'Use this option if you want to display in a language that is different from current page language.'
+    visibility:
+      type: mapping
+      label: Visibility
+      mapping:
+        action:
+          type: string
+          label: Action
+        pages:
+          type: string
+          label: Pages

--- a/modules/oe_webtools_globan/oe_webtools_globan.module
+++ b/modules/oe_webtools_globan/oe_webtools_globan.module
@@ -18,7 +18,9 @@ use Drupal\Core\Url;
  * Attach smart loader.
  */
 function oe_webtools_globan_page_attachments(array &$attachments): void {
-  if (\Drupal::service('router.admin_context')->isAdminRoute()) {
+  /** @var \Drupal\oe_webtools_globan\GlobanVisibilityInterface $visibility */
+  $visibility = \Drupal::service('oe_webtools_goban.visibility');
+  if (!$visibility->shouldDisplayBanner()) {
     return;
   }
 
@@ -38,35 +40,39 @@ function oe_webtools_globan_page_attachments(array &$attachments): void {
  * Implements hook_js_alter().
  */
 function oe_webtools_globan_js_alter(&$javascript, AttachedAssetsInterface $assets) {
-  if (!\Drupal::service('router.admin_context')->isAdminRoute() && isset($javascript['//europa.eu/webtools/load.js'])) {
-    $new_url = UrlHelper::parse($javascript['//europa.eu/webtools/load.js']['data']);
-
-    /** @var \Drupal\Core\Config\ConfigFactoryInterface $config */
-    $config = \Drupal::service('config.factory')->get('oe_webtools_globan.settings');
-
-    $globan_param = empty($config->get('display_eu_flag')) ? '0' : '1';
-
-    switch ($config->get('background_theme')) {
-      case 'light':
-        $globan_param .= '0';
-        break;
-
-      case 'dark':
-        $globan_param .= '1';
-        break;
-
-      default:
-        $globan_param .= '1';
-    }
-
-    $globan_param .= empty($config->get('display_eu_institutions_links')) ? '0' : '1';
-
-    $new_url['query']['globan'] = $globan_param;
-
-    if ($config->get('override_page_lang')) {
-      $new_url['query']['lang'] = $config->get('override_page_lang');
-    }
-
-    $javascript['//europa.eu/webtools/load.js']['data'] = Url::fromUri($new_url['path'], ['query' => $new_url['query']])->toString();
+  /** @var \Drupal\oe_webtools_globan\GlobanVisibilityInterface $visibility */
+  $visibility = \Drupal::service('oe_webtools_goban.visibility');
+  if (!$visibility->shouldDisplayBanner() || !isset($javascript['//europa.eu/webtools/load.js'])) {
+    return;
   }
+
+  $new_url = UrlHelper::parse($javascript['//europa.eu/webtools/load.js']['data']);
+
+  /** @var \Drupal\Core\Config\ConfigFactoryInterface $config */
+  $config = \Drupal::service('config.factory')->get('oe_webtools_globan.settings');
+
+  $globan_param = empty($config->get('display_eu_flag')) ? '0' : '1';
+
+  switch ($config->get('background_theme')) {
+    case 'light':
+      $globan_param .= '0';
+      break;
+
+    case 'dark':
+      $globan_param .= '1';
+      break;
+
+    default:
+      $globan_param .= '1';
+  }
+
+  $globan_param .= empty($config->get('display_eu_institutions_links')) ? '0' : '1';
+
+  $new_url['query']['globan'] = $globan_param;
+
+  if ($config->get('override_page_lang')) {
+    $new_url['query']['lang'] = $config->get('override_page_lang');
+  }
+
+  $javascript['//europa.eu/webtools/load.js']['data'] = Url::fromUri($new_url['path'], ['query' => $new_url['query']])->toString();
 }

--- a/modules/oe_webtools_globan/oe_webtools_globan.post_update.php
+++ b/modules/oe_webtools_globan/oe_webtools_globan.post_update.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for OpenEuropa Webtools Global Banner module.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Provide banner visibility defaults.
+ */
+function oe_webtools_globan_post_update_visibility_defaults(): void {
+  \Drupal::configFactory()->getEditable('oe_webtools_globan.settings')
+    ->set('visibility.action', 'show')
+    ->set('visibility.pages', '')
+    ->save();
+}

--- a/modules/oe_webtools_globan/oe_webtools_globan.services.yml
+++ b/modules/oe_webtools_globan/oe_webtools_globan.services.yml
@@ -4,3 +4,6 @@ services:
     arguments: ['@cache_tags.invalidator']
     tags:
       - { name: event_subscriber }
+  oe_webtools_goban.visibility:
+    class: Drupal\oe_webtools_globan\GlobanVisibility
+    arguments: ['@router.admin_context', '@config.factory', '@plugin.manager.condition']

--- a/modules/oe_webtools_globan/src/Form/WebtoolsGlobanSettingsForm.php
+++ b/modules/oe_webtools_globan/src/Form/WebtoolsGlobanSettingsForm.php
@@ -58,11 +58,7 @@ class WebtoolsGlobanSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('oe_webtools_globan.settings');
 
-    $form['globan_settings'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t('Global banner settings'),
-    ];
-    $form['globan_settings']['display_eu_flag'] = [
+    $form['display_eu_flag'] = [
       '#type' => 'select',
       '#title' => $this->t('Display the EU flag'),
       '#options' => [
@@ -72,7 +68,7 @@ class WebtoolsGlobanSettingsForm extends ConfigFormBase {
       '#description' => $this->t('Hide or show the EU flag icon in the Global Banner.'),
       '#default_value' => empty($config->get('display_eu_flag')) ? 0 : 1,
     ];
-    $form['globan_settings']['background_theme'] = [
+    $form['background_theme'] = [
       '#type' => 'select',
       '#title' => $this->t('Background theme'),
       '#options' => [
@@ -82,7 +78,7 @@ class WebtoolsGlobanSettingsForm extends ConfigFormBase {
       '#description' => $this->t('Whether to show the banner in light or black background.'),
       '#default_value' => $config->get('background_theme') ?? 'dark',
     ];
-    $form['globan_settings']['display_eu_institutions_links'] = [
+    $form['display_eu_institutions_links'] = [
       '#type' => 'select',
       '#title' => $this->t('Link to all EU Institutions and bodies'),
       '#options' => [
@@ -96,7 +92,7 @@ class WebtoolsGlobanSettingsForm extends ConfigFormBase {
     foreach ($this->languageManager->getLanguages() as $language) {
       $lang_options[$language->getId()] = $language->getName();
     }
-    $form['globan_settings']['override_page_lang'] = [
+    $form['override_page_lang'] = [
       '#type' => 'select',
       '#title' => $this->t('Override page language'),
       '#options' => $lang_options,
@@ -104,6 +100,24 @@ class WebtoolsGlobanSettingsForm extends ConfigFormBase {
       '#empty_option' => $this->t('No, use language of current page'),
       '#description' => $this->t('ONLY use this option if you want to display a language, different from current page! The global banner displays in the language of the current page. It supports all 24 EU languages, as well as these non-EU languages.'),
       '#default_value' => $config->get('override_page_lang') ?? NULL,
+    ];
+    $form['visibility'] = [
+      '#type' => 'fieldset',
+      '#tree' => TRUE,
+      '#title' => $this->t('Banner visibility'),
+    ];
+    $form['visibility']['action'] = [
+      '#type' => 'radios',
+      '#options' => [
+        'show' => $this->t('Show for the listed pages'),
+        'hide' => $this->t('Hide for the listed pages'),
+      ],
+      '#default_value' => $config->get('visibility.action'),
+    ];
+    $form['visibility']['pages'] = [
+      '#type' => 'textarea',
+      '#description' => $this->t("Specify pages by using their paths. Enter one path per line. The '*' character is a wildcard. An example path is /user/* for every user page. <front> is the front page. Note that the banner cannot be displayed on administrative pages regardless of this configuration."),
+      '#default_value' => $config->get('visibility.pages'),
     ];
 
     return parent::buildForm($form, $form_state);
@@ -118,6 +132,7 @@ class WebtoolsGlobanSettingsForm extends ConfigFormBase {
       ->set('background_theme', $form_state->getValue('background_theme'))
       ->set('display_eu_institutions_links', (bool) $form_state->getValue('display_eu_institutions_links'))
       ->set('override_page_lang', $form_state->getValue('override_page_lang'))
+      ->set('visibility', $form_state->getValue('visibility'))
       ->save();
     parent::submitForm($form, $form_state);
   }

--- a/modules/oe_webtools_globan/src/GlobanVisibility.php
+++ b/modules/oe_webtools_globan/src/GlobanVisibility.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_webtools_globan;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\Core\Condition\ConditionAccessResolverTrait;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Routing\AdminContext;
+
+/**
+ * Default implementation for the 'oe_webtools_goban.visibility' service.
+ */
+class GlobanVisibility implements GlobanVisibilityInterface {
+
+  use ConditionAccessResolverTrait;
+
+  /**
+   * The route admin context service.
+   *
+   * @var \Drupal\Core\Routing\AdminContext
+   */
+  protected $routeAdminContext;
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The condition plugin manager service.
+   *
+   * @var \Drupal\Component\Plugin\PluginManagerInterface
+   */
+  protected $conditionManager;
+
+  /**
+   * Constructs a new service instance.
+   *
+   * @param \Drupal\Core\Routing\AdminContext $route_admin_context
+   *   The route admin context service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\Component\Plugin\PluginManagerInterface $condition_manager
+   *   The condition plugin manager service.
+   */
+  public function __construct(AdminContext $route_admin_context, ConfigFactoryInterface $config_factory, PluginManagerInterface $condition_manager) {
+    $this->routeAdminContext = $route_admin_context;
+    $this->configFactory = $config_factory;
+    $this->conditionManager = $condition_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function shouldDisplayBanner(): bool {
+    if ($this->routeAdminContext->isAdminRoute()) {
+      return FALSE;
+    }
+
+    $settings = $this->configFactory->get('oe_webtools_globan.settings');
+    // If no page pattern is set, return TRUE.
+    if (!$pages = trim($settings->get('visibility.pages'))) {
+      return TRUE;
+    }
+
+    $negate = ['show' => FALSE, 'hide' => TRUE][$settings->get('visibility.action')];
+
+    /** @var \Drupal\Core\Condition\ConditionInterface $condition */
+    $condition = $this->conditionManager->createInstance('request_path', [
+      'negate' => $negate,
+      'pages' => $pages,
+    ]);
+
+    return $this->resolveConditions([$condition], 'and');
+  }
+
+}

--- a/modules/oe_webtools_globan/src/GlobanVisibilityInterface.php
+++ b/modules/oe_webtools_globan/src/GlobanVisibilityInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_webtools_globan;
+
+/**
+ * Provides a contract for the 'oe_webtools_goban.visibility' service.
+ */
+interface GlobanVisibilityInterface {
+
+  /**
+   * Checks if the banner should be displayed on the current page.
+   *
+   * @return bool
+   *   If the banner should be displayed on the current page.
+   */
+  public function shouldDisplayBanner(): bool;
+
+}

--- a/modules/oe_webtools_globan/tests/src/Functional/ConfigurationTest.php
+++ b/modules/oe_webtools_globan/tests/src/Functional/ConfigurationTest.php
@@ -17,8 +17,7 @@ class ConfigurationTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
-    'config',
-    'system',
+    'contact',
     'oe_webtools_globan',
   ];
 
@@ -26,30 +25,37 @@ class ConfigurationTest extends BrowserTestBase {
    * Tests if the configuration for the Webtools library is present on the page.
    */
   public function testLibraryLoading(): void {
+    $config = $this->config('oe_webtools_globan.settings');
+
     $this->drupalGet('<front>');
     $this->assertSession()->responseContains('<script src="//europa.eu/webtools/load.js?globan=111" defer></script>');
 
-    $config = \Drupal::configFactory()
-      ->getEditable('oe_webtools_globan.settings')
+    $config
       ->set('display_eu_flag', FALSE)
       ->set('background_theme', 'light')
       ->set('display_eu_institutions_links', FALSE)
-      ->set('override_page_lang', '');
-    $config->save();
+      ->set('override_page_lang', '')
+      ->save();
 
     $this->drupalGet('<front>');
     $this->assertSession()->responseContains('<script src="//europa.eu/webtools/load.js?globan=000" defer></script>');
 
-    $config = \Drupal::configFactory()
-      ->getEditable('oe_webtools_globan.settings')
+    $config
       ->set('display_eu_flag', FALSE)
       ->set('background_theme', 'dark')
       ->set('display_eu_institutions_links', TRUE)
-      ->set('override_page_lang', 'it');
-    $config->save();
+      ->set('override_page_lang', 'it')
+      ->save();
 
+    $this->drupalGet('/user');
+    $this->assertSession()->responseContains('<script src="//europa.eu/webtools/load.js?globan=011&amp;lang=it" defer></script>');
+
+    // Show only on front page.
+    $config->set('visibility', ['action' => 'show', 'pages' => '<front>'])->save();
     $this->drupalGet('<front>');
     $this->assertSession()->responseContains('<script src="//europa.eu/webtools/load.js?globan=011&amp;lang=it" defer></script>');
+    $this->drupalGet('/contact');
+    $this->assertSession()->responseNotContains('?globan=');
   }
 
 }

--- a/modules/oe_webtools_globan/tests/src/Kernel/VisibilityServiceTest.php
+++ b/modules/oe_webtools_globan/tests/src/Kernel/VisibilityServiceTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_webtools_globan\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests the 'oe_webtools_goban.visibility' service.
+ *
+ * @group oe_webtools_globan
+ */
+class VisibilityServiceTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'oe_webtools_globan',
+    'system',
+  ];
+
+  /**
+   * Tests the 'oe_webtools_goban.visibility' service.
+   */
+  public function testVisibilityService(): void {
+    $this->installConfig(['oe_webtools_globan', 'system']);
+
+    // Test empty path patterns.
+    $this->assertPathMatchesVisibility('/user/login', 'show', '');
+    $this->assertPathMatchesVisibility('/user', 'show', '');
+    $this->assertPathMatchesVisibility('/user/login', 'hide', '');
+    $this->assertPathMatchesVisibility('/user', 'hide', '');
+
+    // The front page is '/user/login' by default. See system.site config.
+    $this->assertPathMatchesVisibility('/user/login', 'show', '<front>');
+    $this->assertPathNotMatchesVisibility('/user', 'show', '<front>');
+    $this->assertPathNotMatchesVisibility('/contact', 'show', '<front>');
+
+    // Test multiple patterns.
+    $this->assertPathMatchesVisibility('/user/login', 'show', "/user/*\n/contact");
+    $this->assertPathMatchesVisibility('/user/3/edit', 'show', "/user/*\n/contact");
+    $this->assertPathMatchesVisibility('/user/password', 'show', "/user/*\n/contact");
+    $this->assertPathMatchesVisibility('/contact', 'show', "/user/*\n/contact");
+    $this->assertPathNotMatchesVisibility('/user', 'show', "/user/*\n/contact");
+
+    // Test pattern negation.
+    $this->assertPathNotMatchesVisibility('/user/password', 'hide', "/user/*");
+    $this->assertPathNotMatchesVisibility('/user/3/edit', 'hide', "/user/*");
+    $this->assertPathMatchesVisibility('/contact', 'hide', "/user/*");
+  }
+
+  /**
+   * Asserts that a given path satisfies a pattern.
+   *
+   * @param string $path
+   *   The path to be checked.
+   * @param string $action
+   *   The action: 'show' or 'hide'.
+   * @param string $pages
+   *   The list of page patterns as text.
+   */
+  protected function assertPathMatchesVisibility(string $path, string $action, string $pages): void {
+    $this->assertTrue($this->getVisibility($path, $action, $pages));
+  }
+
+  /**
+   * Asserts that a given path doesn't satisfy a pattern.
+   *
+   * @param string $path
+   *   The path to be checked.
+   * @param string $action
+   *   The action: 'show' or 'hide'.
+   * @param string $pages
+   *   The list of page patterns as text.
+   */
+  protected function assertPathNotMatchesVisibility(string $path, string $action, string $pages): void {
+    $this->assertFalse($this->getVisibility($path, $action, $pages));
+  }
+
+  /**
+   * Checks that a given path satisfies a pattern.
+   *
+   * @param string $path
+   *   The path to be checked.
+   * @param string $action
+   *   The action: 'show' or 'hide'.
+   * @param string $pages
+   *   The list of page patterns as text.
+   *
+   * @return bool
+   *   TRUE if the path satisfies the pattern.
+   */
+  protected function getVisibility(string $path, string $action, string $pages): bool {
+    $this->config('oe_webtools_globan.settings')
+      ->set('visibility.action', $action)
+      ->set('visibility.pages', $pages)
+      ->save();
+
+    $request = Request::create($path);
+    $request_stack = $this->container->get('request_stack');
+    $request_stack->pop();
+    $request_stack->push($request);
+
+    $service = $this->container->get('oe_webtools_goban.visibility');
+    return $service->shouldDisplayBanner();
+  }
+
+}


### PR DESCRIPTION
## ISAICP-5648

### Description

Right now, the banner is displayed on all pages. On Joinup project, we have a request to show the banner only on the home page.

### Change log

- Added:
  - New service: `oe_webtools_goban.visibility`
  - New test: `\Drupal\Tests\oe_webtools_globan\Kernel\VisibilityServiceTest`
- Changed: see PR code changes.
- Deprecated: none.
- Removed: none.
- Fixed: none.
- Security: none.

### Commands

N/A
