### PR TITLE
ISAICP-5979: Move 'webtools_snippet' formatter in 'oe_webtools' module

### DIFF
--- a/src/Plugin/Field/FieldFormatter/WebtoolsSnippetFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/WebtoolsSnippetFormatter.php
@@ -2,11 +2,11 @@
 
 declare(strict_types = 1);
 
-namespace Drupal\oe_webtools_media\Plugin\Field\FieldFormatter;
+namespace Drupal\oe_webtools\Plugin\Field\FieldFormatter;
 
 use Drupal\Component\Serialization\Json;
-use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
 use Drupal\json_field\JsonMarkup;
 
 /**
@@ -17,7 +17,7 @@ use Drupal\json_field\JsonMarkup;
  *   label = @Translation("Webtools snippet"),
  *   field_types = {
  *     "json",
- *   }
+ *   },
  * )
  */
 class WebtoolsSnippetFormatter extends FormatterBase {


### PR DESCRIPTION
## ISAICP-5979

### Description

The `webtools_snippet` field formatter looks like a "universal” formatter for any field that wants to expose a Webtools snippet. But, currently, is included in the `oe_webtools_media` module. If a project needs this field formatter but not `oe_webtools_media`, will have to install tons of configs, fields, entity displays which are not used.

Move it to `oe_webtools`, to be reused by other submodules or 3rd party modules.

### Change log

- Moved: The `webtools_snippet` field formatter has been moved from `oe_webtools_media` to `oe_webtools` module.

### Commands

N/A


