### PR TITLE
ISAICP-6273: Avoid CORS issues by requesting the Webtools Smartloader script over HTTPS

### DIFF
--- a/modules/oe_webtools_globan/oe_webtools_globan.module
+++ b/modules/oe_webtools_globan/oe_webtools_globan.module
@@ -38,8 +38,8 @@ function oe_webtools_globan_page_attachments(array &$attachments): void {
  * Implements hook_js_alter().
  */
 function oe_webtools_globan_js_alter(&$javascript, AttachedAssetsInterface $assets) {
-  if (!\Drupal::service('router.admin_context')->isAdminRoute() && isset($javascript['//europa.eu/webtools/load.js'])) {
-    $new_url = UrlHelper::parse($javascript['//europa.eu/webtools/load.js']['data']);
+  if (!\Drupal::service('router.admin_context')->isAdminRoute() && isset($javascript['https://europa.eu/webtools/load.js'])) {
+    $new_url = UrlHelper::parse($javascript['https://europa.eu/webtools/load.js']['data']);
 
     /** @var \Drupal\Core\Config\ConfigFactoryInterface $config */
     $config = \Drupal::service('config.factory')->get('oe_webtools_globan.settings');
@@ -69,6 +69,6 @@ function oe_webtools_globan_js_alter(&$javascript, AttachedAssetsInterface $asse
       $new_url['query']['lang'] = $config->get('override_page_lang');
     }
 
-    $javascript['//europa.eu/webtools/load.js']['data'] = Url::fromUri($new_url['path'], ['query' => $new_url['query']])->toString();
+    $javascript['https://europa.eu/webtools/load.js']['data'] = Url::fromUri($new_url['path'], ['query' => $new_url['query']])->toString();
   }
 }

--- a/modules/oe_webtools_globan/tests/src/Functional/ConfigurationTest.php
+++ b/modules/oe_webtools_globan/tests/src/Functional/ConfigurationTest.php
@@ -27,7 +27,7 @@ class ConfigurationTest extends BrowserTestBase {
    */
   public function testLibraryLoading(): void {
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('<script src="//europa.eu/webtools/load.js?globan=1110" defer></script>');
+    $this->assertSession()->responseContains('<script src="https://europa.eu/webtools/load.js?globan=1110" defer></script>');
 
     $config = \Drupal::configFactory()
       ->getEditable('oe_webtools_globan.settings')
@@ -39,7 +39,7 @@ class ConfigurationTest extends BrowserTestBase {
     $config->save();
 
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('<script src="//europa.eu/webtools/load.js?globan=0000" defer></script>');
+    $this->assertSession()->responseContains('<script src="https://europa.eu/webtools/load.js?globan=0000" defer></script>');
 
     $config = \Drupal::configFactory()
       ->getEditable('oe_webtools_globan.settings')
@@ -51,7 +51,7 @@ class ConfigurationTest extends BrowserTestBase {
     $config->save();
 
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('<script src="//europa.eu/webtools/load.js?globan=0111&amp;lang=it" defer></script>');
+    $this->assertSession()->responseContains('<script src="https://europa.eu/webtools/load.js?globan=0111&amp;lang=it" defer></script>');
   }
 
 }

--- a/oe_webtools.libraries.yml
+++ b/oe_webtools.libraries.yml
@@ -2,4 +2,4 @@
 drupal.webtools-smartloader:
   version: 1.x
   js:
-    "https://europa.eu/webtools/load.js": { external: true, attributes: { defer: true } }
+    https://europa.eu/webtools/load.js: { type: external, attributes: { defer: true } }

--- a/oe_webtools.libraries.yml
+++ b/oe_webtools.libraries.yml
@@ -2,4 +2,4 @@
 drupal.webtools-smartloader:
   version: 1.x
   js:
-   //europa.eu/webtools/load.js: { external: true, attributes: { defer: true } }
+    "https://europa.eu/webtools/load.js": { external: true, attributes: { defer: true } }

--- a/tests/fixtures/static_html/one_map.html
+++ b/tests/fixtures/static_html/one_map.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>A page containing 1 map</title>
-    <script src="//europa.eu/webtools/load.js" async></script>
+    <script src="https://europa.eu/webtools/load.js" async></script>
   </head>
   <body>
     <div>

--- a/tests/fixtures/static_html/two_maps.html
+++ b/tests/fixtures/static_html/two_maps.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>A page containing 1 map</title>
-    <script src="//europa.eu/webtools/load.js" async></script>
+    <script src="https://europa.eu/webtools/load.js" async></script>
   </head>
   <body>
     <div>

--- a/tests/src/Functional/SmartLoaderDependenciesTest.php
+++ b/tests/src/Functional/SmartLoaderDependenciesTest.php
@@ -42,7 +42,7 @@ class SmartLoaderDependenciesTest extends BrowserTestBase {
     $this->container->get('kernel')->invalidateContainer();
 
     $this->drupalGet($url);
-    $this->assertSession()->responseContains('<script src="//europa.eu/webtools/load.js');
+    $this->assertSession()->responseContains('<script src="https://europa.eu/webtools/load.js');
   }
 
   /**


### PR DESCRIPTION
Fixes #148

## ISAICP-6273

### Description

According to the Webtools documentation this resource should be accessed over HTTPS.

Ref. https://webgate.ec.europa.eu/fpfis/wikis/display/webtools/Important+guidelines+for+developers+and+implementers

### Change log

- Changed: The Webtools Smartloader script is requested over HTTPS.