### PR TITLE
ISSUE-153: Drupal 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.8",
         "ext-json": "*",
         "php": ">=7.2"
     },

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/oe_webtools_analytics_rules.info.yml
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/oe_webtools_analytics_rules.info.yml
@@ -2,7 +2,7 @@ name: OpenEuropa Webtools Analytics Rules
 description: Provides rules for customizing the behavior of the Webtools Analytics module.
 package: OpenEuropa Webtools
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 
 dependencies:
   - oe_webtools_analytics:oe_webtools_analytics

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/RuleMatcher.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/src/RuleMatcher.php
@@ -10,7 +10,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Path\AliasManagerInterface;
+use Drupal\path_alias\AliasManagerInterface;
 use Drupal\Core\Path\CurrentPathStack;
 use Drupal\oe_webtools_analytics_rules\Entity\WebtoolsAnalyticsRule;
 use Drupal\oe_webtools_analytics_rules\Entity\WebtoolsAnalyticsRuleInterface;
@@ -24,7 +24,7 @@ class RuleMatcher implements RuleMatcherInterface {
   /**
    * The alias manager service.
    *
-   * @var \Drupal\Core\Path\AliasManagerInterface
+   * @var \Drupal\path_alias\AliasManagerInterface
    */
   protected $aliasManager;
 
@@ -66,7 +66,7 @@ class RuleMatcher implements RuleMatcherInterface {
   /**
    * Constructs a RuleMatcher service.
    *
-   * @param \Drupal\Core\Path\AliasManagerInterface $aliasManager
+   * @param \Drupal\path_alias\AliasManagerInterface $aliasManager
    *   The alias manager service.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   A cache backend used to store webtools rules for uris.

--- a/modules/oe_webtools_analytics/oe_webtools_analytics.info.yml
+++ b/modules/oe_webtools_analytics/oe_webtools_analytics.info.yml
@@ -3,7 +3,7 @@ description: Provides the configuration settings for webtools analytics integrat
 package: OpenEuropa Webtools
 type: module
 version: 1.0
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 configure: oe_webtools_analytics.settings
 
 dependencies:

--- a/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.info.yml
+++ b/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.info.yml
@@ -2,7 +2,7 @@ name: OpenEuropa Webtools Cookie Consent
 description: Provides the Cookie Consent Kit service functionality.
 package: OpenEuropa Webtools
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 configure: oe_webtools_cookie_consent.settings
 
 dependencies:

--- a/modules/oe_webtools_geocoding/oe_webtools_geocoding.info.yml
+++ b/modules/oe_webtools_geocoding/oe_webtools_geocoding.info.yml
@@ -3,7 +3,7 @@ description: Allows to use the Webtools Geocoder service in sites built on the O
 package: OpenEuropa Webtools
 
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 
 dependencies:
   - geocoder:geocoder

--- a/modules/oe_webtools_globan/oe_webtools_globan.info.yml
+++ b/modules/oe_webtools_globan/oe_webtools_globan.info.yml
@@ -3,7 +3,7 @@ description: Provides the configuration settings for webtools global banner inte
 package: OpenEuropa Webtools
 type: module
 version: 1.0
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 configure: oe_webtools_globan.settings
 dependencies:
   - oe_webtools:oe_webtools

--- a/modules/oe_webtools_laco_service/oe_webtools_laco_service.info.yml
+++ b/modules/oe_webtools_laco_service/oe_webtools_laco_service.info.yml
@@ -3,4 +3,4 @@ description: Provides the Webtools Language Coverage (LACO) service.
 package: OpenEuropa Webtools
 type: module
 version: 1.0
-core: 8.x
+core_version_requirement: ^8.8 || ^9

--- a/modules/oe_webtools_laco_widget/oe_webtools_laco_widget.info.yml
+++ b/modules/oe_webtools_laco_widget/oe_webtools_laco_widget.info.yml
@@ -2,7 +2,7 @@ name: OpenEuropa Webtools Laco Widget
 description: Adds a widget for Webtools Laco.
 package: OpenEuropa Webtools
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 
 dependencies:
   - oe_webtools:oe_webtools

--- a/modules/oe_webtools_maps/oe_webtools_maps.info.yml
+++ b/modules/oe_webtools_maps/oe_webtools_maps.info.yml
@@ -3,7 +3,7 @@ description: Allows to use Webtools Maps in sites built on the OpenEuropa platfo
 package: OpenEuropa Webtools
 
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 
 dependencies:
   - geofield:geofield

--- a/modules/oe_webtools_media/oe_webtools_media.info.yml
+++ b/modules/oe_webtools_media/oe_webtools_media.info.yml
@@ -2,7 +2,7 @@ name: OpenEuropa Webtools Media
 description: Provides Webtools Widgets as supported media providers.
 package: OpenEuropa Webtools
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 dependencies:
   - drupal:media
   - json_field:json_field

--- a/modules/oe_webtools_media/oe_webtools_media.install
+++ b/modules/oe_webtools_media/oe_webtools_media.install
@@ -22,8 +22,7 @@ function oe_webtools_media_install() {
   $file_system = \Drupal::service('file_system');
   $file_system->prepareDirectory($destination, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
 
-  // @TODO Replace after canceling backward compatibility with core 8.7.
-  $files = file_scan_directory($source, '/.*\.(png)$/');
+  $files = $file_system->scanDirectory($source, '/.*\.(png)$/');
   foreach ($files as $file) {
     // When reinstalling the OE Webtools media module we don't want to copy
     // the icons when

--- a/modules/oe_webtools_media/oe_webtools_media.post_update.php
+++ b/modules/oe_webtools_media/oe_webtools_media.post_update.php
@@ -22,8 +22,7 @@ function oe_webtools_media_post_update_00001(): void {
   $file_system = \Drupal::service('file_system');
   $file_system->prepareDirectory($destination, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
 
-  // @TODO Replace after canceling backward compatibility with core 8.7.
-  $files = file_scan_directory($source, '/.*\.(png)$/');
+  $files = $file_system->scanDirectory($source, '/.*\.(png)$/');
   foreach ($files as $file) {
     if (!file_exists($destination . DIRECTORY_SEPARATOR . $file->filename)) {
       try {

--- a/modules/oe_webtools_social_share/modules/oe_webtools_social_share_demo/oe_webtools_social_share_demo.info.yml
+++ b/modules/oe_webtools_social_share/modules/oe_webtools_social_share_demo/oe_webtools_social_share_demo.info.yml
@@ -2,7 +2,7 @@ name: OpenEuropa Webtools Social Share Demo
 description: Provide demo for webtools social share module.
 package: OpenEuropa Webtools
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 
 dependencies:
   - oe_webtools:oe_webtools_social_share

--- a/modules/oe_webtools_social_share/oe_webtools_social_share.info.yml
+++ b/modules/oe_webtools_social_share/oe_webtools_social_share.info.yml
@@ -2,7 +2,7 @@ name: OpenEuropa Webtools Social Share
 description: Provide social sharing functionality for a site.
 package: OpenEuropa Webtools
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 
 dependencies:
   - oe_webtools:oe_webtools

--- a/oe_webtools.info.yml
+++ b/oe_webtools.info.yml
@@ -2,4 +2,4 @@ name: Webtools integration
 description: OpenEuropa Webtools integration.
 package: OpenEuropa Webtools
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9


### PR DESCRIPTION
## ISSUE-153

### Description

Drupal 9 compatibility

### Change log

- Changed: 'core' key to 'core_version_requirement' key in info.yml files
- Removed: 'drupal/core' dependency from composer.json
- Fixed: Reference to deprecated interface: Drupal\Core\Path\AliasManagerInterface -> Drupal\path_alias\AliasManagerInterface
- Fixed: Use of deprecated function: file_scan_directory()

