### PR TITLE
OEL-1996: Fix PHP 8.1 deprecation but keep PHP 7.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require-dev": {
         "behat/behat": "^3.10",
         "composer/installers": "~1.5",
-        "drupal/coder": "^8.3.15",
         "drupal/config_devel": "~1.2",
         "drupal/core-composer-scaffold": "^9.3",
         "drupal/core-dev": "^9.3",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require-dev": {
         "behat/behat": "^3.10",
         "composer/installers": "~1.5",
+        "cweagans/composer-patches": "^1.7",
         "drupal/config_devel": "~1.2",
         "drupal/core-composer-scaffold": "^9.3",
         "drupal/core-dev": "^9.3",
@@ -61,6 +62,11 @@
     "extra": {
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,
+        "patches": {
+            "drupal/coder": {
+                "https://www.drupal.org/project/coder/issues/3250986": "https://patch-diff.githubusercontent.com/raw/pfrenssen/coder/pull/157.diff"
+            }
+        },
         "installer-paths": {
             "build/core": ["type:drupal-core"],
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require-dev": {
         "behat/behat": "^3.10",
         "composer/installers": "~1.5",
-        "cweagans/composer-patches": "^1.7",
         "drupal/config_devel": "~1.2",
         "drupal/core-composer-scaffold": "^9.3",
         "drupal/core-dev": "^9.3",
@@ -62,11 +61,6 @@
     "extra": {
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,
-        "patches": {
-            "drupal/coder": {
-                "https://www.drupal.org/project/coder/issues/3250986": "https://patch-diff.githubusercontent.com/raw/pfrenssen/coder/pull/157.diff"
-            }
-        },
         "installer-paths": {
             "build/core": ["type:drupal-core"],
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require-dev": {
         "behat/behat": "^3.10",
         "composer/installers": "~1.5",
+        "drupal/coder": "^8.3.15",
         "drupal/config_devel": "~1.2",
         "drupal/core-composer-scaffold": "^9.3",
         "drupal/core-dev": "^9.3",

--- a/modules/oe_webtools_analytics/src/Event/AnalyticsEvent.php
+++ b/modules/oe_webtools_analytics/src/Event/AnalyticsEvent.php
@@ -46,7 +46,7 @@ class AnalyticsEvent extends Event implements \JsonSerializable, AnalyticsEventI
    *
    * @var string[]
    */
-  protected $sitePath;
+  protected $sitePath = [];
 
   /**
    * Set this variable to true on your 404 page.

--- a/modules/oe_webtools_analytics/src/Event/AnalyticsEvent.php
+++ b/modules/oe_webtools_analytics/src/Event/AnalyticsEvent.php
@@ -240,6 +240,7 @@ class AnalyticsEvent extends Event implements \JsonSerializable, AnalyticsEventI
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     $data = [
       self::UTILITY => $this->getUtility(),

--- a/modules/oe_webtools_analytics/src/Search/SearchParameters.php
+++ b/modules/oe_webtools_analytics/src/Search/SearchParameters.php
@@ -102,6 +102,7 @@ class SearchParameters implements SearchParametersInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter([
       'keyword' => $this->getKeyword(),


### PR DESCRIPTION
## [OEL-1996](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-1996)

### Description

With PHP 8.1, we get this message:

> Return type of Drupal\oe_webtools_analytics\Event\AnalyticsEvent::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

### Change log

- Added: `#[\ReturnTypeWillChange]` to `AnalyticsEvent::jsonSerialize()`. Note, that we cannot change the return typing as we still support PHP 7.4 but the mixed pseudo type was added only on PHP 8.0.
- Changed: None.
- Deprecated: None.
- Removed: None.
- Fixed: None.
- Security: None.

### Commands

n/a