### PR TITLE
#202 PHP 8.1 compatibility issue with jsonSerialize() function.

### DIFF
--- a/modules/oe_webtools_maps/src/Component/Render/JsonEncoded.php
+++ b/modules/oe_webtools_maps/src/Component/Render/JsonEncoded.php
@@ -59,7 +59,7 @@ class JsonEncoded implements MarkupInterface {
   /**
    * {@inheritdoc}
    */
-  public function jsonSerialize() {
+  public function jsonSerialize(): mixed {
     return Json::encode($this->json);
   }
 


### PR DESCRIPTION
PR Fixing #202 

### Description

With PHP 8.1 the log is full of error like this

Deprecated function: Return type of Drupal\oe_webtools_analytics\Search\SearchParameters::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 14 of /var/www/..../web/modules/contrib/oe_webtools/modules/oe_webtools_analytics/src/Search/SearchParameters.php)


### Change log

Added ":mixed " to all jsonSerialize() functions as elsewhere in similar modules: https://www.drupal.org/project/google_analytics/issues/3312418


