### PR TITLE
Fix PHP8 deprecation notice

### DIFF
--- a/modules/oe_webtools_maps/src/Component/Render/JsonEncoded.php
+++ b/modules/oe_webtools_maps/src/Component/Render/JsonEncoded.php
@@ -59,7 +59,7 @@ class JsonEncoded implements MarkupInterface {
   /**
    * {@inheritdoc}
    */
-  public function jsonSerialize() {
+  public function jsonSerialize(): mixed {
     return Json::encode($this->json);
   }
 


### PR DESCRIPTION
PR Fixing #202 

### Description

With PHP 8 the log shows:

```
Deprecated function: Return type of Drupal\oe_webtools_maps\Component\Render\JsonEncoded::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 13 of modules/contrib/oe_webtools/modules/oe_webtools_maps/src/Component/Render/JsonEncoded.php).
```
