### PR TITLE
OEL-3156: Placed widgets inside the body tag

### DIFF
--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Functional/SectionRulesTest.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Functional/SectionRulesTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\oe_webtools_analytics_rules\Functional;
 
 use Drupal\oe_webtools_analytics\AnalyticsEventInterface;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
 
 /**
  * Tests for defining site sections using regular expressions.
@@ -13,6 +14,8 @@ use Drupal\Tests\BrowserTestBase;
  * @group oe_webtools_analytics
  */
 class SectionRulesTest extends BrowserTestBase {
+
+  use ContentAssertionTrait;
 
   /**
    * {@inheritdoc}
@@ -61,19 +64,16 @@ class SectionRulesTest extends BrowserTestBase {
 
     // Frontpage doesn't match any rule so it doesn't render a section.
     $this->drupalGet('<front>');
-    $this->assertSession()
-      ->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"]}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"]}');
 
     // The administration page matches the first rule so it renders section1.
     $this->drupalGet('admin');
-    $this->assertSession()
-      ->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"siteSection":"section1","is403":true}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"siteSection":"section1","is403":true}');
 
     // The configuration page matches both rules but since they have the same
     // weight, the first rule is applied and section1 is rendered.
     $this->drupalGet('admin/config');
-    $this->assertSession()
-      ->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"siteSection":"section1","is403":true}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"siteSection":"section1","is403":true}');
 
     // Change weight of rules.
     /** @var \Drupal\oe_webtools_analytics_rules\Entity\WebtoolsAnalyticsRuleInterface $id2 */
@@ -93,9 +93,7 @@ class SectionRulesTest extends BrowserTestBase {
     // The configuration page matches both rules but since the second rule
     // is now lighter the second rule is applied and section2 is rendered.
     $this->drupalGet('admin/config');
-    $this->assertSession()
-      ->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"siteSection":"section2","is403":true}</script>');
-
+    $this->assertBodyContainsApplicationJson('{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"siteSection":"section2","is403":true}');
   }
 
 }

--- a/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Functional/SectionRulesTest.php
+++ b/modules/oe_webtools_analytics/modules/oe_webtools_analytics_rules/tests/src/Functional/SectionRulesTest.php
@@ -6,7 +6,7 @@ namespace Drupal\Tests\oe_webtools_analytics_rules\Functional;
 
 use Drupal\oe_webtools_analytics\AnalyticsEventInterface;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
+use Drupal\Tests\oe_webtools\Traits\ApplicationJsonAssertTrait;
 
 /**
  * Tests for defining site sections using regular expressions.
@@ -15,7 +15,7 @@ use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
  */
 class SectionRulesTest extends BrowserTestBase {
 
-  use ContentAssertionTrait;
+  use ApplicationJsonAssertTrait;
 
   /**
    * {@inheritdoc}

--- a/modules/oe_webtools_analytics/oe_webtools_analytics.module
+++ b/modules/oe_webtools_analytics/oe_webtools_analytics.module
@@ -21,9 +21,10 @@ function oe_webtools_analytics_page_bottom(array &$page_bottom) {
   $existing_cache = CacheableMetadata::createFromRenderArray($page_bottom);
   $event_cache = CacheableMetadata::createFromObject($event);
 
+  $cache = $existing_cache->merge($event_cache);
+  $cache->applyTo($page_bottom);
+
   if (!$event->isValid()) {
-    $cache = $existing_cache->merge($event_cache);
-    $cache->applyTo($page_bottom);
     return;
   }
 

--- a/modules/oe_webtools_analytics/oe_webtools_analytics.module
+++ b/modules/oe_webtools_analytics/oe_webtools_analytics.module
@@ -27,8 +27,6 @@ function oe_webtools_analytics_page_bottom(array &$page_bottom) {
     return;
   }
 
-  $event_cache->applyTo($page_bottom);
-
   $page_bottom['oe_webtools_cookie_consent'][] = [
     '#type' => 'html_tag',
     '#tag' => 'script',

--- a/modules/oe_webtools_analytics/oe_webtools_analytics.module
+++ b/modules/oe_webtools_analytics/oe_webtools_analytics.module
@@ -11,36 +11,29 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\oe_webtools_analytics\Event\AnalyticsEvent;
 
 /**
- * Implements hook_page_attachments().
- *
- * Collects the Analytics settings and sets them as a JSON snippet.
+ * Implements hook_page_bottom().
  */
-function oe_webtools_analytics_page_attachments(array &$attachments): void {
+function oe_webtools_analytics_page_bottom(array &$page_bottom) {
   $event = new AnalyticsEvent();
   $event_dispatcher = \Drupal::service('event_dispatcher');
   $event_dispatcher->dispatch($event, AnalyticsEvent::NAME);
 
-  $existing_cache = CacheableMetadata::createFromRenderArray($attachments);
+  $existing_cache = CacheableMetadata::createFromRenderArray($page_bottom);
   $event_cache = CacheableMetadata::createFromObject($event);
 
   if (!$event->isValid()) {
     $cache = $existing_cache->merge($event_cache);
-    $cache->applyTo($attachments);
+    $cache->applyTo($page_bottom);
     return;
   }
 
-  $analytics_attachment = [
+  $event_cache->applyTo($page_bottom);
+
+  $page_bottom['oe_webtools_cookie_consent'][] = [
     '#type' => 'html_tag',
     '#tag' => 'script',
     '#value' => $event,
     '#attributes' => ['type' => 'application/json'],
   ];
-
-  $event_cache->applyTo($attachments);
-  $attachments['#attached']['html_head'][] = [
-    $analytics_attachment,
-    // A key, to make it possible to recognize this when altering.
-    'oe_webtools_analytics',
-  ];
-  $attachments['#attached']['library'][] = 'oe_webtools/drupal.webtools-smartloader';
+  $page_bottom['#attached']['library'][] = 'oe_webtools/drupal.webtools-smartloader';
 }

--- a/modules/oe_webtools_analytics/tests/src/Functional/ConfigurationTest.php
+++ b/modules/oe_webtools_analytics/tests/src/Functional/ConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_webtools_analytics\Functional;
 
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
 
 /**
  * Tests that the configured settings are correctly output in the page.
@@ -12,6 +13,8 @@ use Drupal\Tests\BrowserTestBase;
  * @group oe_webtools_analytics
  */
 class ConfigurationTest extends BrowserTestBase {
+
+  use ContentAssertionTrait;
 
   /**
    * {@inheritdoc}
@@ -42,13 +45,13 @@ class ConfigurationTest extends BrowserTestBase {
 
     $this->drupalLogout();
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"instance":"testing"}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"instance":"testing"}');
 
     $this->drupalGet('not-existing-page');
-    $this->assertSession()->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"is404":true,"instance":"testing"}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"is404":true,"instance":"testing"}');
 
     $this->drupalGet('admin');
-    $this->assertSession()->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"is403":true,"instance":"testing"}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"piwik","siteID":"123","sitePath":["ec.europa.eu"],"is403":true,"instance":"testing"}');
 
     // Test the cache invalidation.
     $this->drupalLogin($user);
@@ -58,7 +61,7 @@ class ConfigurationTest extends BrowserTestBase {
 
     $this->drupalLogout();
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('<script type="application/json">{"utility":"piwik","siteID":"123e4567-e89b-12d3-a456-426614174000","sitePath":["ec.europa.eu"],"instance":"testing"}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"piwik","siteID":"123e4567-e89b-12d3-a456-426614174000","sitePath":["ec.europa.eu"],"instance":"testing"}');
   }
 
 }

--- a/modules/oe_webtools_analytics/tests/src/Functional/ConfigurationTest.php
+++ b/modules/oe_webtools_analytics/tests/src/Functional/ConfigurationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_webtools_analytics\Functional;
 
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
+use Drupal\Tests\oe_webtools\Traits\ApplicationJsonAssertTrait;
 
 /**
  * Tests that the configured settings are correctly output in the page.
@@ -14,7 +14,7 @@ use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
  */
 class ConfigurationTest extends BrowserTestBase {
 
-  use ContentAssertionTrait;
+  use ApplicationJsonAssertTrait;
 
   /**
    * {@inheritdoc}

--- a/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.module
+++ b/modules/oe_webtools_cookie_consent/oe_webtools_cookie_consent.module
@@ -18,20 +18,21 @@ use Drupal\oe_webtools_cookie_consent\Form\WebtoolsCookieConsentSettingsForm;
 const OE_WEBTOOLS_COOKIE_CONSENT_EMBED_COOKIE_URL = '//webtools.europa.eu/crs/iframe/';
 
 /**
- * Implements hook_page_attachments().
+ * Implements hook_page_bottom().
  */
-function oe_webtools_cookie_consent_page_attachments(array &$attachments) {
+function oe_webtools_cookie_consent_page_bottom(array &$page_bottom) {
   $event = new ConfigBannerPopupEvent();
   $event_dispatcher = \Drupal::service('event_dispatcher');
   $event_dispatcher->dispatch($event, ConfigBannerPopupEvent::NAME);
 
   $event_cache = CacheableMetadata::createFromObject($event);
-  $existing_cache = CacheableMetadata::createFromRenderArray($attachments);
+  $existing_cache = CacheableMetadata::createFromRenderArray($page_bottom);
 
   $cache = $event_cache->merge($existing_cache);
-  $cache->applyTo($attachments);
+  $cache->applyTo($page_bottom);
+
   if ($event->isBannerPopup()) {
-    $attachments['#attached']['library'][] = 'oe_webtools/drupal.webtools-smartloader';
+    $page_bottom['#attached']['library'][] = 'oe_webtools/drupal.webtools-smartloader';
     $script_values = [
       'utility' => 'cck',
     ];
@@ -40,17 +41,12 @@ function oe_webtools_cookie_consent_page_attachments(array &$attachments) {
     if ($url) {
       $script_values['url'] = $url;
     }
-    $cck_attachment = [
+
+    $page_bottom['oe_webtools_cookie_consent'][] = [
       '#type' => 'html_tag',
       '#tag' => 'script',
       '#value' => Json::encode($script_values),
       '#attributes' => ['type' => 'application/json'],
-    ];
-
-    $event_cache->applyTo($attachments);
-    $attachments['#attached']['html_head'][] = [
-      $cck_attachment,
-      'oe_webtools_cookie_consent',
     ];
   }
 }

--- a/modules/oe_webtools_cookie_consent/tests/src/Functional/CookieConsentTest.php
+++ b/modules/oe_webtools_cookie_consent/tests/src/Functional/CookieConsentTest.php
@@ -6,11 +6,14 @@ namespace Drupal\Tests\oe_webtools_cookie_consent\Functional;
 
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
 
 /**
  * Check if the Laco widget code is on the front page.
  */
 class CookieConsentTest extends BrowserTestBase {
+
+  use ContentAssertionTrait;
 
   /**
    * {@inheritdoc}
@@ -62,7 +65,7 @@ class CookieConsentTest extends BrowserTestBase {
     // Re-assert again as anonymous user.
     $this->drupalLogout();
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('{"utility":"cck","url":"' . addcslashes('http://example.com/cookie', '/') . '"}');
+    $this->assertBodyContainsApplicationJson('{"utility":"cck","url":"' . addcslashes('http://example.com/cookie', '/') . '"}');
 
     // Translate the cookie consent URL.
     $this->drupalLogin($user);
@@ -76,9 +79,9 @@ class CookieConsentTest extends BrowserTestBase {
     // Re-assert as anonymous user.
     $this->drupalLogout();
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('{"utility":"cck","url":"' . addcslashes('http://example.com/cookie', '/') . '"}');
+    $this->assertBodyContainsApplicationJson('{"utility":"cck","url":"' . addcslashes('http://example.com/cookie', '/') . '"}');
     $this->drupalGet('/fr');
-    $this->assertSession()->responseContains('{"utility":"cck","url":"' . addcslashes('http://example.com/fr/cookie', '/') . '"}');
+    $this->assertBodyContainsApplicationJson('{"utility":"cck","url":"' . addcslashes('http://example.com/fr/cookie', '/') . '"}');
 
     // Disable CCK.
     $this->drupalLogin($user);

--- a/modules/oe_webtools_cookie_consent/tests/src/Functional/CookieConsentTest.php
+++ b/modules/oe_webtools_cookie_consent/tests/src/Functional/CookieConsentTest.php
@@ -6,14 +6,14 @@ namespace Drupal\Tests\oe_webtools_cookie_consent\Functional;
 
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
+use Drupal\Tests\oe_webtools\Traits\ApplicationJsonAssertTrait;
 
 /**
  * Check if the Laco widget code is on the front page.
  */
 class CookieConsentTest extends BrowserTestBase {
 
-  use ContentAssertionTrait;
+  use ApplicationJsonAssertTrait;
 
   /**
    * {@inheritdoc}

--- a/modules/oe_webtools_globan/tests/src/Functional/ConfigurationTest.php
+++ b/modules/oe_webtools_globan/tests/src/Functional/ConfigurationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_webtools_globan\Functional;
 
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
+use Drupal\Tests\oe_webtools\Traits\ApplicationJsonAssertTrait;
 
 /**
  * Tests that the configured settings are correctly output in the page.
@@ -14,7 +14,7 @@ use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
  */
 class ConfigurationTest extends BrowserTestBase {
 
-  use ContentAssertionTrait;
+  use ApplicationJsonAssertTrait;
 
   /**
    * {@inheritdoc}

--- a/modules/oe_webtools_globan/tests/src/Functional/ConfigurationTest.php
+++ b/modules/oe_webtools_globan/tests/src/Functional/ConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_webtools_globan\Functional;
 
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
 
 /**
  * Tests that the configured settings are correctly output in the page.
@@ -12,6 +13,8 @@ use Drupal\Tests\BrowserTestBase;
  * @group oe_webtools_globan
  */
 class ConfigurationTest extends BrowserTestBase {
+
+  use ContentAssertionTrait;
 
   /**
    * {@inheritdoc}
@@ -32,7 +35,7 @@ class ConfigurationTest extends BrowserTestBase {
    */
   public function testLibraryLoading(): void {
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('<script type="application/json">{"utility":"globan","theme":"dark","logo":true,"link":true,"mode":false}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"globan","theme":"dark","logo":true,"link":true,"mode":false}');
 
     $config = \Drupal::configFactory()
       ->getEditable('oe_webtools_globan.settings')
@@ -44,7 +47,7 @@ class ConfigurationTest extends BrowserTestBase {
     $config->save();
 
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('<script type="application/json">{"utility":"globan","theme":"light","logo":false,"link":false,"mode":false}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"globan","theme":"light","logo":false,"link":false,"mode":false}');
 
     $config = \Drupal::configFactory()
       ->getEditable('oe_webtools_globan.settings')
@@ -56,7 +59,7 @@ class ConfigurationTest extends BrowserTestBase {
     $config->save();
 
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('<script type="application/json">{"utility":"globan","theme":"dark","logo":false,"link":true,"mode":true,"lang":"it"}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"globan","theme":"dark","logo":false,"link":true,"mode":true,"lang":"it"}');
 
     $config = \Drupal::configFactory()
       ->getEditable('oe_webtools_globan.settings')
@@ -70,7 +73,7 @@ class ConfigurationTest extends BrowserTestBase {
     $config->save();
 
     $this->drupalGet('<front>');
-    $this->assertSession()->responseContains('<script type="application/json">{"utility":"globan","theme":"dark","logo":false,"link":true,"mode":true,"lang":"it","zindex":0}</script>');
+    $this->assertBodyContainsApplicationJson('{"utility":"globan","theme":"dark","logo":false,"link":true,"mode":true,"lang":"it","zindex":0}');
   }
 
 }

--- a/modules/oe_webtools_laco_widget/oe_webtools_laco_widget.module
+++ b/modules/oe_webtools_laco_widget/oe_webtools_laco_widget.module
@@ -10,9 +10,9 @@ declare(strict_types=1);
 use Drupal\Core\Cache\CacheableMetadata;
 
 /**
- * Implements hook_page_attachments().
+ * Implements hook_page_bottom().
  */
-function oe_webtools_laco_widget_page_attachments(array &$attachments) {
+function oe_webtools_laco_widget_page_bottom(array &$page_bottom) {
   $logger = \Drupal::logger('oe_webtools_laco_widget');
   $config = \Drupal::config('oe_webtools_laco_widget.settings');
 
@@ -48,18 +48,15 @@ function oe_webtools_laco_widget_page_attachments(array &$attachments) {
     $json['ignore'] = $ignore;
   }
 
-  $attachments['#attached']['html_head'][] = [
-    [
-      '#type' => 'html_tag',
-      '#tag' => 'script',
-      '#value' => json_encode($json),
-      '#attributes' => ['type' => 'application/json'],
-    ],
-    'oe_webtools_laco_widget',
+  $page_bottom['oe_webtools_cookie_consent'][] = [
+    '#type' => 'html_tag',
+    '#tag' => 'script',
+    '#value' => json_encode($json),
+    '#attributes' => ['type' => 'application/json'],
   ];
 
-  $attachments['#attached']['library'][] = 'oe_webtools/drupal.webtools-smartloader';
-  $cache = CacheableMetadata::createFromRenderArray($attachments);
+  $page_bottom['#attached']['library'][] = 'oe_webtools/drupal.webtools-smartloader';
+  $cache = CacheableMetadata::createFromRenderArray($page_bottom);
   $cache->addCacheableDependency($config);
-  $cache->applyTo($attachments);
+  $cache->applyTo($page_bottom);
 }

--- a/modules/oe_webtools_laco_widget/tests/src/Functional/LacoWidgetTest.php
+++ b/modules/oe_webtools_laco_widget/tests/src/Functional/LacoWidgetTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_webtools_laco_widget\Functional;
 
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
 
 /**
  * Check if the Laco widget code is on the front page.
  */
 class LacoWidgetTest extends BrowserTestBase {
+
+  use ContentAssertionTrait;
 
   /**
    * {@inheritdoc}
@@ -28,14 +31,12 @@ class LacoWidgetTest extends BrowserTestBase {
    */
   public function testLacoScriptLoading():void {
     $this->drupalGet('<front>');
-    $this->assertSession()
-      ->responseContains('<script type="application/json">{"service":"laco","include":"body","coverage":{"document":"any","page":"any"},"icon":"all","exclude":".nolaco, .more-link, .pager"}</script>');
+    $this->assertBodyContainsApplicationJson('{"service":"laco","include":"body","coverage":{"document":"any","page":"any"},"icon":"all","exclude":".nolaco, .more-link, .pager"}');
     \Drupal::configFactory()->getEditable('oe_webtools_laco_widget.settings')
       ->set('ignore', ['/fr/', '/en/'])
       ->save();
     $this->drupalGet('<front>');
-    $this->assertSession()
-      ->responseContains('<script type="application/json">{"service":"laco","include":"body","coverage":{"document":"any","page":"any"},"icon":"all","exclude":".nolaco, .more-link, .pager","ignore":["\/fr\/","\/en\/"]}</script>');
+    $this->assertBodyContainsApplicationJson('{"service":"laco","include":"body","coverage":{"document":"any","page":"any"},"icon":"all","exclude":".nolaco, .more-link, .pager","ignore":["\/fr\/","\/en\/"]}');
   }
 
 }

--- a/modules/oe_webtools_laco_widget/tests/src/Functional/LacoWidgetTest.php
+++ b/modules/oe_webtools_laco_widget/tests/src/Functional/LacoWidgetTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_webtools_laco_widget\Functional;
 
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
+use Drupal\Tests\oe_webtools\Traits\ApplicationJsonAssertTrait;
 
 /**
  * Check if the Laco widget code is on the front page.
  */
 class LacoWidgetTest extends BrowserTestBase {
 
-  use ContentAssertionTrait;
+  use ApplicationJsonAssertTrait;
 
   /**
    * {@inheritdoc}

--- a/modules/oe_webtools_page_feedback/tests/src/Functional/PageFeedbackFormTest.php
+++ b/modules/oe_webtools_page_feedback/tests/src/Functional/PageFeedbackFormTest.php
@@ -6,11 +6,14 @@ namespace Drupal\Tests\oe_webtools_page_feedback\FunctionalJavascript;
 
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
 
 /**
  * Tests the Page Feedback Form webtools widget.
  */
 class PageFeedbackFormTest extends BrowserTestBase {
+
+  use ContentAssertionTrait;
 
   /**
    * {@inheritdoc}
@@ -54,14 +57,14 @@ class PageFeedbackFormTest extends BrowserTestBase {
     // language.
     $this->drupalGet('/node/1');
     $this->assertSession()->pageTextContains('Page node');
-    $this->assertSession()->responseContains('<script type="application/json">{"service":"dff","id":"1234","lang":"en","version":"2.0"}</script>');
+    $this->assertBodyContainsApplicationJson('{"service":"dff","id":"1234","lang":"en","version":"2.0"}');
     $this->drupalGet('<front>');
     $this->assertSession()->responseNotContains('"service":"dff"');
     $this->drupalGet('/pt-pt/node/1');
-    $this->assertSession()->responseContains('<script type="application/json">{"service":"dff","id":"1234","lang":"pt","version":"2.0"}</script>');
+    $this->assertBodyContainsApplicationJson('{"service":"dff","id":"1234","lang":"pt","version":"2.0"}');
     $page_feedback_config->set('feedback_form_id', '1234abc')->save();
     $this->drupalGet('/pt-pt/node/1');
-    $this->assertSession()->responseContains('<script type="application/json">{"service":"dff","id":"1234abc","lang":"pt","version":"2.0"}</script>');
+    $this->assertBodyContainsApplicationJson('{"service":"dff","id":"1234abc","lang":"pt","version":"2.0"}');
 
     // Disable the block and assert the block is not rendered and the cache was
     // properly invalidated.

--- a/modules/oe_webtools_page_feedback/tests/src/Functional/PageFeedbackFormTest.php
+++ b/modules/oe_webtools_page_feedback/tests/src/Functional/PageFeedbackFormTest.php
@@ -6,14 +6,14 @@ namespace Drupal\Tests\oe_webtools_page_feedback\FunctionalJavascript;
 
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\oe_webtools\Traits\ContentAssertionTrait;
+use Drupal\Tests\oe_webtools\Traits\ApplicationJsonAssertTrait;
 
 /**
  * Tests the Page Feedback Form webtools widget.
  */
 class PageFeedbackFormTest extends BrowserTestBase {
 
-  use ContentAssertionTrait;
+  use ApplicationJsonAssertTrait;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Traits/ApplicationJsonAssertTrait.php
+++ b/tests/src/Traits/ApplicationJsonAssertTrait.php
@@ -7,7 +7,7 @@ namespace Drupal\Tests\oe_webtools\Traits;
 /**
  * Helper methods to deal with asserting page content.
  */
-trait ContentAssertionTrait {
+trait ApplicationJsonAssertTrait {
 
   /**
    * Asserts that the page body contains the application JSON.

--- a/tests/src/Traits/ContentAssertionTrait.php
+++ b/tests/src/Traits/ContentAssertionTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\oe_webtools\Traits;
+
+/**
+ * Helper methods to deal with asserting page content.
+ */
+trait ContentAssertionTrait {
+
+  /**
+   * Asserts that the page body contains the application JSON.
+   *
+   * @param string $json
+   *   The application JSON.
+   */
+  protected function assertBodyContainsApplicationJson(string $json): void {
+    $application_json = '<script type="application/json">' . $json . '</script>';
+    $actual = $this->getSession()->getPage()->find('css', 'body')->getHtml();
+    $message = sprintf('"%s" was not found anywhere in the HTML body.', $application_json);
+
+    $this->assertTrue(stripos($actual, $application_json) !== FALSE, $message);
+  }
+
+}


### PR DESCRIPTION
## OEL-3156

### Description

All widgets ("application/json") should be placed inside the body tag as described in webtools documentation: https://webgate.ec.europa.eu/fpfis/wikis/display/webtools/Widgets

### Change log

- Changed: From hook_page_attachments to hook_page_bottom


