### PR TITLE
EWPP-4784: Do not add LACO widget if all coverage options are disabled.

### DIFF
--- a/modules/oe_webtools_laco_widget/oe_webtools_laco_widget.module
+++ b/modules/oe_webtools_laco_widget/oe_webtools_laco_widget.module
@@ -16,8 +16,18 @@ function oe_webtools_laco_widget_page_bottom(array &$page_bottom) {
   $logger = \Drupal::logger('oe_webtools_laco_widget');
   $config = \Drupal::config('oe_webtools_laco_widget.settings');
 
+  $cache = CacheableMetadata::createFromRenderArray($page_bottom);
+  $cache->addCacheableDependency($config);
+  $cache->applyTo($page_bottom);
+
   // Do not add LACO widget related JSON if it is disabled in the config.
   if (!$config->get('enabled')) {
+    return;
+  }
+
+  // Do not add LACO widget related JSON if both coverage options are disabled.
+  $coverage = $config->get('coverage');
+  if (($coverage['document'] === 'false') && ($coverage['page'] === 'false')) {
     return;
   }
 
@@ -32,8 +42,8 @@ function oe_webtools_laco_widget_page_bottom(array &$page_bottom) {
     'service' => 'laco',
     'include' => implode(', ', $include),
     'coverage' => [
-      'document' => $config->get('coverage.document'),
-      'page' => $config->get('coverage.page'),
+      'document' => $coverage['document'],
+      'page' => $coverage['page'],
     ],
     'icon' => $config->get('icon'),
   ];
@@ -56,7 +66,4 @@ function oe_webtools_laco_widget_page_bottom(array &$page_bottom) {
   ];
 
   $page_bottom['#attached']['library'][] = 'oe_webtools/drupal.webtools-smartloader';
-  $cache = CacheableMetadata::createFromRenderArray($page_bottom);
-  $cache->addCacheableDependency($config);
-  $cache->applyTo($page_bottom);
 }

--- a/modules/oe_webtools_laco_widget/tests/src/Functional/LacoWidgetTest.php
+++ b/modules/oe_webtools_laco_widget/tests/src/Functional/LacoWidgetTest.php
@@ -37,6 +37,12 @@ class LacoWidgetTest extends BrowserTestBase {
       ->save();
     $this->drupalGet('<front>');
     $this->assertBodyContainsApplicationJson('{"service":"laco","include":"body","coverage":{"document":"any","page":"any"},"icon":"all","exclude":".nolaco, .more-link, .pager","ignore":["\/fr\/","\/en\/"]}');
+    \Drupal::configFactory()->getEditable('oe_webtools_laco_widget.settings')
+      ->set('coverage.document', 'false')
+      ->set('coverage.page', 'false')
+      ->save();
+    $this->drupalGet('<front>');
+    $this->assertSession()->responseNotContains('<script type="application/json">{"service":"laco"');
   }
 
 }


### PR DESCRIPTION
## EWPP-4784

### Description

The LACO widget will not be added to the page, if all coverage options are set to "false".

