### PR TITLE
D8TEFD-1822: Fix drupal non ISO langcode.

### DIFF
--- a/modules/oe_webtools_etrans/README.md
+++ b/modules/oe_webtools_etrans/README.md
@@ -33,3 +33,12 @@ To use the OpenEuropa Unified eTrans block, ensure the following steps are compl
 Once a user visits a page that does not have a translation available and is browsing the website in a language
 other than the default one, they will be presented with a banner offering them the opportunity 
 to translate the page using the eTrans service.
+
+## Using path alias for non translated entities
+
+The purpose of the unified eTrans block is to allow users to navigate the website in their preferred language. 
+When using [pathauto](https://www.drupal.org/project/pathauto), URL aliases are generated for translated pages. 
+However, non-translated pages will still use the default Drupal path (/node/nid) when accessed by users.
+
+Currently, there is a [patch available](https://www.drupal.org/project/pathauto/issues/2946354) that enables 
+the use of the default language alias for untranslated content.

--- a/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
+++ b/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
@@ -312,13 +312,22 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
   }
 
   /**
-   * Attempt to map langcode to ISO 639-1.
+   * Attempts to map a Drupal langcode to ISO 639-1 as expected by Webtools.
+   *
+   * Language codes in Drupal are based on w3c language tags.
+   * For most (European) languages, these are identical with the ISO-639-1
+   * code.
+   * In some cases, the language code in Drupal has an additional suffix to
+   * distinguish regional variants, e.g. 'pt-pt' vs 'pt-br'.
+   * In other cases, Drupal uses a different ISO 639-1 code than Webtools
+   * does: For Norwegian, Drupal has 'nb' for Bokmal, whereas Webtools expects
+   * the more generic 'no' for Norwegian.
    *
    * @param string $langcode
    *   The Drupal langcode.
    *
    * @return string
-   *   The ISO 639-1 langcode format.
+   *   The corresponding ISO 639-1 language code as expected by Webtools.
    */
   protected function mapLangcodeToIso(string $langcode): string {
     // In Drupal, langcode are often in ISO 639-1 format by default.

--- a/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
+++ b/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\oe_webtools_etrans\Plugin\Block;
 
 use Drupal\Component\Serialization\Json;
-use Drupal\Component\Serialization\Yaml;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\Attribute\Block;
@@ -325,9 +324,7 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
     // In Drupal, langcode are often in ISO 639-2 format by default.
     // But, some languages use browser formats like 'pt-pt' or 'ta-lk'.
     // A mapping exists in the language module.
-    $mapping_file = file_get_contents(DRUPAL_ROOT . '/core/modules/language/config/install/language.mappings.yml');
-    $mapping = Yaml::decode($mapping_file ?: '');
-    $mapping = array_flip($mapping['map'] ?? []);
+    $mapping = array_flip(language_get_browser_drupal_langcode_mappings());
     if (isset($mapping[$langcode])) {
       return substr($mapping[$langcode], 0, 2);
     }

--- a/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
+++ b/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
@@ -153,7 +153,7 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
     ];
     $disclaimer_link = [
       '#type' => 'link',
-      '#url' => Url::fromUri('https://commission.europa.eu/languages-our-websites/use-machine-translation-europa_' . $current_language->getId(), [
+      '#url' => Url::fromUri('https://commission.europa.eu/languages-our-websites/use-machine-translation-europa_' . $langcode_to, [
         'attributes' => [
           'class' => ['webtools-etrans--disclaimer'],
           'target' => '_blank',
@@ -312,16 +312,16 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
   }
 
   /**
-   * Attempt to map langcode to ISO 639-2.
+   * Attempt to map langcode to ISO 639-1.
    *
    * @param string $langcode
    *   The drupal langcode.
    *
    * @return string
-   *   The ISO 639-2 langcode format.
+   *   The ISO 639-1 langcode format.
    */
   protected function mapLangcodeToIso(string $langcode): string {
-    // In Drupal, langcode are often in ISO 639-2 format by default.
+    // In Drupal, langcode are often in ISO 639-1 format by default.
     // But, some languages use browser formats like 'pt-pt' or 'ta-lk'.
     // A mapping exists in the language module.
     $mapping = array_flip(language_get_browser_drupal_langcode_mappings());

--- a/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
+++ b/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
@@ -333,6 +333,8 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
     // Get the browser language lookup map from language module.
     // This maps different alternative language codes to their corresponding
     // Drupal language codes.
+    // @todo The browser language map is not really meant for this purpose.
+    //   It just happens to do what we need in the most common scenarios.
     $mappings = language_get_browser_drupal_langcode_mappings();
     // Get alternative language codes for the given Drupal langcode.
     $alternative_codes = array_keys($mappings, $langcode, TRUE);
@@ -342,7 +344,8 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
       if ($alternative_short_codes) {
         // An alternative two-letter code exists.
         // We assume that this is the ISO 639-1 code expected by Webtools.
-        // This happens to be true at least with the default language mappings.
+        // This happens to be true at least with the default language mappings
+        // from core/modules/language/config/install/language.mappings.yml.
         return reset($alternative_short_codes);
       }
     }

--- a/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
+++ b/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
@@ -102,11 +102,11 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
     // On node route, we take the node original language,
     // which is not necessarily the default language of the website.
     $current_language = $this->languageManager->getCurrentLanguage();
-    $iso_langcode_from = $this->getRouteEntityLangcode(TRUE) ?: $this->languageManager->getDefaultLanguage()->getId();
-    $iso_langcode_to = $current_language->getId();
+    $langcode_from = $this->getRouteEntityLangcode(TRUE) ?: $this->languageManager->getDefaultLanguage()->getId();
+    $langcode_to = $current_language->getId();
 
-    $iso_langcode_from = $this->mapLangcodeToIso($iso_langcode_from);
-    $iso_langcode_to = $this->mapLangcodeToIso($iso_langcode_to);
+    $iso_langcode_from = $this->mapLangcodeToIso($langcode_from);
+    $iso_langcode_to = $this->mapLangcodeToIso($langcode_to);
 
     $json = $this->preparesWtEtransJson($iso_langcode_from, $placeholder_id);
 

--- a/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
+++ b/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
@@ -330,16 +330,25 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
    *   The corresponding ISO 639-1 language code as expected by Webtools.
    */
   protected function mapLangcodeToIso(string $langcode): string {
-    // In Drupal, langcode are often in ISO 639-1 format by default.
-    // But, some languages use browser formats like 'pt-pt' or 'ta-lk'.
-    // A mapping exists in the language module.
-    $mapping = array_flip(language_get_browser_drupal_langcode_mappings());
-    if (isset($mapping[$langcode])) {
-      return substr($mapping[$langcode], 0, 2);
+    // Get the browser language lookup map from language module.
+    // This maps different alternative language codes to their corresponding
+    // Drupal language codes.
+    $mappings = language_get_browser_drupal_langcode_mappings();
+    // Get alternative language codes for the given Drupal langcode.
+    $alternative_codes = array_keys($mappings, $langcode, TRUE);
+    if ($alternative_codes) {
+      // Look for alternative codes with two letters.
+      $alternative_short_codes = array_filter($alternative_codes, fn (string $code) => strlen($code) === 2);
+      if ($alternative_short_codes) {
+        // An alternative two-letter code exists.
+        // We assume that this is the ISO 639-1 code expected by Webtools.
+        // This happens to be true at least with the default language mappings.
+        return reset($alternative_short_codes);
+      }
     }
-    // In some cases, users may add languages that are not standard.
-    // Due to this variability, the format of langcode is unpredictable.
-    // Therefore, we use only the first two characters as a best guess.
+    // No alternative two-letter codes found.
+    // Return the first two letters of the Drupal language code, which should be
+    // the ISO 639-1 code, at least for most European languages.
     return substr($langcode, 0, 2);
   }
 

--- a/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
+++ b/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
@@ -102,13 +102,13 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
     // On node route, we take the node original language,
     // which is not necessarily the default language of the website.
     $current_language = $this->languageManager->getCurrentLanguage();
-    $langcode_from = $this->getRouteEntityLangcode(TRUE) ?: $this->languageManager->getDefaultLanguage()->getId();
-    $langcode_to = $current_language->getId();
+    $iso_langcode_from = $this->getRouteEntityLangcode(TRUE) ?: $this->languageManager->getDefaultLanguage()->getId();
+    $iso_langcode_to = $current_language->getId();
 
-    $langcode_from = $this->mapLangcodeToIso($langcode_from);
-    $langcode_to = $this->mapLangcodeToIso($langcode_to);
+    $iso_langcode_from = $this->mapLangcodeToIso($iso_langcode_from);
+    $iso_langcode_to = $this->mapLangcodeToIso($iso_langcode_to);
 
-    $json = $this->preparesWtEtransJson($langcode_from, $placeholder_id);
+    $json = $this->preparesWtEtransJson($iso_langcode_from, $placeholder_id);
 
     // Returns UEC webtool eTrans widget.
     $build['etrans_uec'] = [
@@ -124,7 +124,7 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
         ],
         'drupalSettings' => [
           'path' => [
-            'languageTo' => $langcode_to,
+            'languageTo' => $iso_langcode_to,
           ],
         ],
       ],
@@ -153,7 +153,7 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
     ];
     $disclaimer_link = [
       '#type' => 'link',
-      '#url' => Url::fromUri('https://commission.europa.eu/languages-our-websites/use-machine-translation-europa_' . $langcode_to, [
+      '#url' => Url::fromUri('https://commission.europa.eu/languages-our-websites/use-machine-translation-europa_' . $iso_langcode_to, [
         'attributes' => [
           'class' => ['webtools-etrans--disclaimer'],
           'target' => '_blank',

--- a/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
+++ b/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
@@ -315,7 +315,7 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
    * Attempt to map langcode to ISO 639-1.
    *
    * @param string $langcode
-   *   The drupal langcode.
+   *   The Drupal langcode.
    *
    * @return string
    *   The ISO 639-1 langcode format.

--- a/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
+++ b/modules/oe_webtools_etrans/src/Plugin/Block/UnifiedEtransBlock.php
@@ -347,9 +347,10 @@ class UnifiedEtransBlock extends BlockBase implements ContainerFactoryPluginInte
       }
     }
     // No alternative two-letter codes found.
-    // Return the first two letters of the Drupal language code, which should be
-    // the ISO 639-1 code, at least for most European languages.
-    return substr($langcode, 0, 2);
+    // Return the first part of the Drupal language code, before the first '-'.
+    // For most European languages, this should be the ISO 639-1 code.
+    // Do not use substr(*, 0, 2), to not cut 3-letter codes.
+    return explode('-', $langcode, 2)[0];
   }
 
 }

--- a/modules/oe_webtools_etrans/tests/src/FunctionalJavascript/UnifiedEtransBlockTest.php
+++ b/modules/oe_webtools_etrans/tests/src/FunctionalJavascript/UnifiedEtransBlockTest.php
@@ -115,6 +115,18 @@ class UnifiedEtransBlockTest extends WebDriverTestBase {
     ]));
     $this->assertSession()->pageTextContains("Ja sam tekst koji će biti preveden.");
     $this->assertSession()->pageTextNotContains("Croatian is available via eTranslation, the European Commission's machine translation service.");
+
+    // Tests the mapping of regional language codes in
+    // UnifiedEtransBlock::mapLangcodeToIso(). While mapping was incorrect,
+    // nothing happened when clicking on the link 'Translate to Portuguese'.
+    $this->drupalGet($node->toUrl(NULL, [
+      'language' => ConfigurableLanguage::load('pt-pt'),
+    ]));
+    $this->assertSession()->pageTextContains("I'm a text that will be translated.");
+    $this->assertSession()->pageTextContains("Portuguese is available via eTranslation, the European Commission's machine translation service.");
+    $this->clickLink('Translate to Portuguese');
+    $this->assertSession()->pageTextContains("Tradução em curso. Por favor aguarde.");
+    $this->assertSession()->linkExists("Cancelar tradução");
   }
 
   /**


### PR DESCRIPTION
## D8TEFD-1822

### Description

Issue #271

### Change log

- Added: mapLangcodeToIso, a function that attempts to get drupal langcode in ISO 639-2 expected by webtools.

