### PR TITLE
Fix fatal error: Cannot use object of type stdClass as array.

### DIFF
--- a/tests/Behat/WebtoolsMapsContext.php
+++ b/tests/Behat/WebtoolsMapsContext.php
@@ -67,25 +67,25 @@ class WebtoolsMapsContext extends RawDrupalContext {
       foreach ($hashed_data as $type => $value) {
         switch ($type) {
           case 'name':
-            if ($map_data->layers[0]->markers->features[0]->properties->name !== $value) {
+            if ($map_data->layers->markers[0]->data->features[0]->properties->name !== $value) {
               continue 3;
             }
             break;
 
           case 'description':
-            if ($map_data->layers[0]->markers->features[0]->properties->description !== $value) {
+            if ($map_data->layers->markers[0]->data->features[0]->properties->description !== $value) {
               continue 3;
             }
             break;
 
           case 'latitude':
-            if ((string) $map_data->layers[0]->markers->features[0]->geometry->coordinates[1] !== $value) {
+            if ((string) $map_data->layers->markers[0]->data->features[0]->geometry->coordinates[1] !== $value) {
               continue 3;
             }
             break;
 
           case 'longitude':
-            if ((string) $map_data->layers[0]->markers->features[0]->geometry->coordinates[0] !== $value) {
+            if ((string) $map_data->layers->markers[0]->data->features[0]->geometry->coordinates[0] !== $value) {
               continue 3;
             }
             break;


### PR DESCRIPTION
Issue #280

An additional change following the update to Maps 3.0 is located in the file **tests/Behat/WebtoolsMapsContext.php**
Example:
```
-            if ($map_data->layers[0]->markers->features[0]->properties->name !== $value) {
+            if ($map_data->layers->markers[0]->data->features[0]->properties->name !== $value) {
```