### PR TITLE
Issue-292: Guard against null values in webtools_snippet format…

### DIFF
--- a/src/Plugin/Field/FieldFormatter/WebtoolsSnippetFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/WebtoolsSnippetFormatter.php
@@ -29,13 +29,17 @@ class WebtoolsSnippetFormatter extends FormatterBase {
     $element = [];
 
     foreach ($items as $delta => $item) {
+      $value = Json::decode($item->get('value')->getValue());
+      if (\json_last_error() !== JSON_ERROR_NONE || !\is_array($value)) {
+        continue;
+      }
       $element[$delta] = [
         '#type' => 'html_tag',
         '#tag' => 'script',
         // We need to properly escape the json content before outputting in the
         // page. We cannot use twig escaping mechanism as it will use html
         // entities. Json::encode takes care of it.
-        '#value' => new JsonEncoded(Json::decode($item->get('value')->getValue())),
+        '#value' => new JsonEncoded($value),
         '#attributes' => ['type' => 'application/json'],
       ];
     }


### PR DESCRIPTION
…ter.

## OPENEUROPA-[292]

### Description

[Update WebtoolsSnippetFormatter to decode the field value and skip rendering when the result is not an array.]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

