### PR TITLE
Don't use deprecating casting

### DIFF
--- a/modules/oe_webtools_cookie_consent/src/EventSubscriber/WebtoolsCookieConsentEventSubscriber.php
+++ b/modules/oe_webtools_cookie_consent/src/EventSubscriber/WebtoolsCookieConsentEventSubscriber.php
@@ -47,7 +47,7 @@ class WebtoolsCookieConsentEventSubscriber implements EventSubscriberInterface {
     $event->addCacheableDependency($config);
 
     $config_data = $config->get('banner_popup');
-    $event->setBannerPopup((boolean) $config_data);
+    $event->setBannerPopup((bool) $config_data);
   }
 
   /**
@@ -61,7 +61,7 @@ class WebtoolsCookieConsentEventSubscriber implements EventSubscriberInterface {
     $event->addCacheableDependency($config);
 
     $config_data = $config->get('video_popup');
-    $event->setVideoPopup((boolean) $config_data);
+    $event->setVideoPopup((bool) $config_data);
   }
 
   /**


### PR DESCRIPTION
Closes #310 

See https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.non-canonical-cast-names